### PR TITLE
Mark io.druid artifact stable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,9 @@ The current stable version is:
 
 ```xml
 <dependency>
-  <groupId>com.metamx</groupId>
+  <groupId>io.druid</groupId>
   <artifactId>tranquility_2.10</artifactId>
-  <version>0.4.2</version>
+  <version>0.5.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
It's the same as the previous stable (0.4.2) with some changes to packaging
and one code change: b22d8b14.

I think the changes are pretty low risk but it would still be cool if someone has the
opportunity to try this artifact out before merging this PR.