### PR TITLE
Add contentType as parameter

### DIFF
--- a/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
+++ b/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
@@ -102,7 +102,7 @@ class DruidBeam[A : Timestamper](
           (location.environment.firehoseServicePattern format task.firehoseId)
       ) withEffect {
         req =>
-          req.headers.set("Content-Type", "application/json")
+          req.headers.set("Content-Type", objectWriter.contentType)
           req.headers.set("Content-Length", eventsChunk.length)
           req.setContent(ChannelBuffers.wrappedBuffer(eventsChunk))
       }

--- a/src/main/scala/com/metamx/tranquility/typeclass/JavaObjectWriter.scala
+++ b/src/main/scala/com/metamx/tranquility/typeclass/JavaObjectWriter.scala
@@ -32,4 +32,9 @@ trait JavaObjectWriter[A]
    * of objects.
    */
   def batchAsBytes(objects: java.util.Iterator[A]): Array[Byte]
+
+  /**
+   * @return content type of the serialized form
+   */
+  def contentType: String
 }

--- a/src/main/scala/com/metamx/tranquility/typeclass/JsonWriter.scala
+++ b/src/main/scala/com/metamx/tranquility/typeclass/JsonWriter.scala
@@ -19,10 +19,13 @@ package com.metamx.tranquility.typeclass
 import com.fasterxml.jackson.core.{JsonFactory, JsonGenerator}
 import com.metamx.common.scala.Predef._
 import java.io.ByteArrayOutputStream
+import javax.ws.rs.core.MediaType
 
 abstract class JsonWriter[A] extends ObjectWriter[A]
 {
   @transient private lazy val _jsonFactory = new JsonFactory
+
+  override def contentType: String = MediaType.APPLICATION_JSON
 
   override def asBytes(a: A): Array[Byte] = {
     val out = new ByteArrayOutputStream

--- a/src/main/scala/com/metamx/tranquility/typeclass/ObjectWriter.scala
+++ b/src/main/scala/com/metamx/tranquility/typeclass/ObjectWriter.scala
@@ -33,12 +33,20 @@ trait ObjectWriter[A] extends Serializable
    * of objects.
    */
   def batchAsBytes(objects: TraversableOnce[A]): Array[Byte]
+
+  /**
+   * @return content type of the serialized form
+   */
+  def contentType: String
 }
 
 object ObjectWriter
 {
   def wrap[A](javaObjectWriter: JavaObjectWriter[A]): ObjectWriter[A] = new ObjectWriter[A] {
     override def asBytes(obj: A) = javaObjectWriter.asBytes(obj)
+
     override def batchAsBytes(objects: TraversableOnce[A]) = javaObjectWriter.batchAsBytes(objects.toIterator.asJava)
+
+    override def contentType = javaObjectWriter.contentType
   }
 }

--- a/src/test/java/com/metamx/tranquility/javatests/StormJavaApiTest.java
+++ b/src/test/java/com/metamx/tranquility/javatests/StormJavaApiTest.java
@@ -32,10 +32,12 @@ import com.metamx.tranquility.storm.BeamBolt;
 import com.metamx.tranquility.storm.BeamFactory;
 import com.metamx.tranquility.typeclass.JavaObjectWriter;
 import com.metamx.tranquility.typeclass.Timestamper;
+import com.sun.jersey.core.header.MediaTypes;
 import com.twitter.finagle.Service;
 import io.druid.granularity.QueryGranularity;
 import io.druid.query.aggregation.AggregatorFactory;
 import io.druid.query.aggregation.CountAggregatorFactory;
+import javax.ws.rs.core.MediaType;
 import junit.framework.Assert;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
@@ -131,6 +133,12 @@ public class StormJavaApiTest
                     catch (JsonProcessingException e) {
                       throw Throwables.propagate(e);
                     }
+                  }
+
+                  @Override
+                  public String contentType()
+                  {
+                    return MediaType.APPLICATION_JSON;
                   }
                 }
             );

--- a/src/test/scala/com/metamx/tranquility/test/DirectDruidTest.scala
+++ b/src/test/scala/com/metamx/tranquility/test/DirectDruidTest.scala
@@ -42,6 +42,7 @@ import io.druid.data.input.impl.TimestampSpec
 import io.druid.granularity.QueryGranularity
 import io.druid.query.aggregation.LongSumAggregatorFactory
 import java.{util => ju}
+import javax.ws.rs.core.MediaType
 import org.apache.curator.framework.CuratorFramework
 import org.joda.time.DateTime
 import org.scala_tools.time.Imports._
@@ -138,6 +139,11 @@ class DirectDruidTest
             val packed = "[%s]" format strings.mkString(", ")
             packed.getBytes
           }
+
+          /**
+           * @return content type of the serialized form
+           */
+          override def contentType: String = MediaType.APPLICATION_JSON
         }).buildService()
         try {
           timekeeper.now = new DateTime().hourOfDay().roundFloorCopy()


### PR DESCRIPTION
Add option to extend contentType. 
Can be used to send data to druid in smile format. 