### PR TITLE
Use UTC DateTimes and Intervals whenever making decisions involving segments.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
@@ -22,7 +22,6 @@ import com.metamx.common.scala.Logging
 import com.metamx.common.scala.Predef._
 import com.metamx.common.scala.event.WARN
 import com.metamx.common.scala.event.emit.emitAlert
-import com.metamx.common.scala.timekeeper.Timekeeper
 import com.metamx.common.scala.untyped._
 import com.metamx.emitter.service.ServiceEmitter
 import com.metamx.tranquility.beam.Beam
@@ -51,7 +50,6 @@ class DruidBeam[A : Timestamper](
   finagleRegistry: FinagleRegistry,
   indexService: IndexService,
   emitter: ServiceEmitter,
-  timekeeper: Timekeeper,
   objectWriter: ObjectWriter[A]
 ) extends Beam[A] with Logging
 {

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -172,7 +172,6 @@ object DruidBeams
         things.finagleRegistry,
         indexService,
         things.emitter,
-        things.timekeeper,
         things.objectWriter
       )
       val clusteredBeam = new ClusteredBeam(


### PR DESCRIPTION
This should make the time partitioning stuff work even if the user's timezone
is something other than UTC, or if the Timekeeper or Timestamper return
non-UTC times.