### PR TITLE
Nix extraneous samza jars for 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,5 +169,6 @@ lazy val samza = project.in(file("samza"))
   // don't compile or publish for Scala > 2.10
   .settings((skip in compile) := scalaVersion { sv => ! sv.startsWith("2.10.") }.value)
   .settings((skip in test) := scalaVersion { sv => !sv.startsWith("2.10.") }.value)
-  .settings(publishArtifact in packageBin <<= scalaVersion { sv => sv.startsWith("2.10.") })
+  .settings(publishArtifact <<= scalaVersion { sv => sv.startsWith("2.10.") })
+  .settings(publishArtifact in Test := false)
   .dependsOn(core % "test->test;compile->compile")


### PR DESCRIPTION
This gets rid of all the samza 2.11 jars: sources, javadocs, etc.

After this I am pretty sure only the jars we want to get published will get published.

```
tranquility-core_2.10-javadoc.jar
tranquility-core_2.10-sources.jar
tranquility-core_2.10-tests.jar
tranquility-core_2.10.jar
tranquility-core_2.10.pom
tranquility-core_2.11-javadoc.jar
tranquility-core_2.11-sources.jar
tranquility-core_2.11-tests.jar
tranquility-core_2.11.jar
tranquility-core_2.11.pom
tranquility-samza_2.10-javadoc.jar
tranquility-samza_2.10-sources.jar
tranquility-samza_2.10.jar
tranquility-samza_2.10.pom
tranquility-storm_2.10-javadoc.jar
tranquility-storm_2.10-sources.jar
tranquility-storm_2.10.jar
tranquility-storm_2.10.pom
tranquility-storm_2.11-javadoc.jar
tranquility-storm_2.11-sources.jar
tranquility-storm_2.11.jar
tranquility-storm_2.11.pom
```