### PR TITLE
Rollup-aware partitioning by default for Maps, and a Partitioner interface for other types.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/partition/GenericTimeAndDimsPartitioner.scala
+++ b/core/src/main/scala/com/metamx/tranquility/partition/GenericTimeAndDimsPartitioner.scala
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.partition
+
+import com.google.common.hash.Hashing
+import com.metamx.common.scala.Logging
+import com.metamx.tranquility.druid.DruidRollup
+import com.metamx.tranquility.typeclass.Timestamper
+import io.druid.data.input.impl.TimestampSpec
+import java.util.concurrent.atomic.AtomicBoolean
+import java.{util => ju}
+import org.scala_tools.time.Imports._
+import scala.collection.JavaConverters._
+
+object GenericTimeAndDimsPartitioner
+{
+  private val StringSeparator: Byte = 0xff.toByte
+
+  /**
+    * Create a Partitioner that can partition Scala and Java Maps according to their Druid grouping key (truncated
+    * timestamp and dimensions). For other types, you should implement your own Partitioner that accesses your
+    * object's fields directly.
+    */
+  def create[A](
+    timestamper: Timestamper[A],
+    timestampSpec: TimestampSpec,
+    rollup: DruidRollup
+  ): Partitioner[A] =
+  {
+    new GenericTimeAndDimsPartitioner[A](
+      timestamper,
+      timestampSpec,
+      rollup
+    )
+  }
+}
+
+class GenericTimeAndDimsPartitioner[A](
+  timestamper: Timestamper[A],
+  timestampSpec: TimestampSpec,
+  rollup: DruidRollup
+) extends Partitioner[A] with Logging
+{
+  @transient private val didWarn = new AtomicBoolean
+
+  override def partition(thing: A, numPartitions: Int): Int = {
+    val dimensions = thing match {
+      case scalaMap: collection.Map[_, _] =>
+        for ((k: String, v) <- scalaMap if rollup.isStringDimension(timestampSpec, k)) yield {
+          (k, v)
+        }
+
+      case javaMap: ju.Map[_, _] =>
+        for ((k: String, v) <- javaMap.asScala if rollup.isStringDimension(timestampSpec, k)) yield {
+          (k, v)
+        }
+
+      case obj =>
+        // Oops, we don't really know how to do things other than Maps...
+        if (didWarn.compareAndSet(false, true)) {
+          log.warn(
+            "Cannot partition object of class[%s] by time and dimensions. Consider implementing a Partitioner.",
+            obj.getClass
+          )
+        }
+        Nil
+    }
+
+    val partitionHashCode = if (dimensions.nonEmpty) {
+      val truncatedTimestamp = rollup.indexGranularity.truncate(timestamper.timestamp(thing).millis)
+      Partitioner.timeAndDimsHashCode(truncatedTimestamp, dimensions)
+    } else {
+      thing.hashCode()
+    }
+
+    Hashing.consistentHash(partitionHashCode, numPartitions)
+  }
+}

--- a/core/src/main/scala/com/metamx/tranquility/partition/HashCodePartitioner.scala
+++ b/core/src/main/scala/com/metamx/tranquility/partition/HashCodePartitioner.scala
@@ -17,13 +17,17 @@
  * under the License.
  */
 
-package com.metamx.tranquility.beam
+package com.metamx.tranquility.partition
 
-import com.metamx.tranquility.partition.HashCodePartitioner
+import com.google.common.hash.Hashing
 
-class HashPartitionBeam[A](
-  beams: IndexedSeq[Beam[A]]
-) extends MergingPartitioningBeam[A](new HashCodePartitioner[A], beams)
+/**
+  * Partitioner that uses the hashCode of the underlying object. This is rarely going to be what you want, but at
+  * least it's simple.
+  */
+class HashCodePartitioner[A] extends Partitioner[A]
 {
-  override def toString = s"HashPartitionBeam(${beams.mkString(", ")})"
+  override def partition(a: A, numPartitions: Int): Int = {
+    Hashing.consistentHash(a.hashCode(), numPartitions)
+  }
 }

--- a/core/src/main/scala/com/metamx/tranquility/partition/Partitioner.scala
+++ b/core/src/main/scala/com/metamx/tranquility/partition/Partitioner.scala
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.partition
+
+import com.google.common.base.Charsets
+import com.google.common.hash.Hashing
+import java.{util => ju}
+import scala.collection.JavaConverters._
+import scala.collection.immutable.SortedMap
+import scala.collection.immutable.SortedSet
+
+/**
+  * Class that knows how to partition objects of a certain type into an arbitrary number of buckets. This is
+  * generally used along with a MergingPartitioningBeam to create a beamMergeFn.
+  */
+trait Partitioner[-A] extends Serializable
+{
+  def partition(a: A, numPartitions: Int): Int
+}
+
+object Partitioner
+{
+  /**
+    * Helper function for use by Partitioner implementations. Computes a hash code derived from a message's
+    * truncated timestamp and its dimensions.
+    *
+    * @param truncatedTimestamp timestamp, truncated to indexGranularity
+    * @param dimensions iterable of (dim name, dim value) tuples. The dim value can be a String,
+    * @return
+    */
+  def timeAndDimsHashCode(truncatedTimestamp: Long, dimensions: Iterable[(String, Any)]): Int = {
+    val hasher = Hashing.murmur3_32().newHasher()
+    hasher.putLong(truncatedTimestamp)
+
+    for ((dimName, dimValue) <- SortedMap(dimensions.toSeq: _*)) {
+      val dimValueAsStrings: Set[String] = dimValue match {
+        case x: String if x.nonEmpty =>
+          Set(x)
+
+        case x: Number =>
+          Set(String.valueOf(x))
+
+        case xs: ju.List[_] =>
+          SortedSet(xs.asScala.filterNot(s => s == null).map(String.valueOf): _*).filterNot(_.isEmpty)
+
+        case xs: Seq[_] =>
+          SortedSet(xs.filterNot(s => s == null).map(String.valueOf): _*).filterNot(_.isEmpty)
+
+        case _ =>
+          Set.empty
+      }
+
+      // This is not a one-to-one mapping, but that's okay, since we're only using it for hashing and
+      // not for an equality check. Some moderate collisions are fine.
+      if (dimValueAsStrings.nonEmpty) {
+        hasher.putBytes(dimName.getBytes(Charsets.UTF_8))
+        for (s <- dimValueAsStrings) {
+          hasher.putBytes(s.getBytes(Charsets.UTF_8))
+        }
+      }
+    }
+
+    hasher.hash().asInt()
+  }
+}

--- a/core/src/main/scala/com/metamx/tranquility/typeclass/Timestamper.scala
+++ b/core/src/main/scala/com/metamx/tranquility/typeclass/Timestamper.scala
@@ -18,7 +18,7 @@ package com.metamx.tranquility.typeclass
 
 import org.joda.time.DateTime
 
-trait Timestamper[A] extends Serializable
+trait Timestamper[-A] extends Serializable
 {
   def timestamp(a: A): DateTime
 }

--- a/core/src/test/java/com/metamx/tranquility/javatests/JavaApiTest.java
+++ b/core/src/test/java/com/metamx/tranquility/javatests/JavaApiTest.java
@@ -53,7 +53,7 @@ public class JavaApiTest
         QueryGranularity.MINUTE
     );
     Assert.assertTrue(rollup.dimensions() instanceof SpecificDruidDimensions);
-    Assert.assertEquals("column", ((SpecificDruidDimensions) rollup.dimensions()).dimensions().apply(0));
+    Assert.assertEquals("column", ((SpecificDruidDimensions) rollup.dimensions()).dimensions().iterator().next());
   }
 
   @Test
@@ -77,7 +77,7 @@ public class JavaApiTest
         QueryGranularity.MINUTE
     );
     Assert.assertTrue(rollup.dimensions() instanceof SchemalessDruidDimensions);
-    Assert.assertEquals("column", ((SchemalessDruidDimensions) rollup.dimensions()).dimensionExclusions().apply(0));
+    Assert.assertEquals("column", ((SchemalessDruidDimensions) rollup.dimensions()).dimensionExclusions().iterator().next());
   }
 
   @Test
@@ -97,8 +97,8 @@ public class JavaApiTest
         QueryGranularity.MINUTE
     );
     Assert.assertTrue(rollup.dimensions() instanceof SchemalessDruidDimensions);
-    Assert.assertEquals("column", ((SchemalessDruidDimensions) rollup.dimensions()).dimensionExclusions().apply(0));
-    Assert.assertEquals("coord.geo", rollup.dimensions().spatialDimensions().apply(0).schema().getDimName());
+    Assert.assertEquals("column", ((SchemalessDruidDimensions) rollup.dimensions()).dimensionExclusions().iterator().next());
+    Assert.assertEquals("coord.geo", rollup.dimensions().spatialDimensions().iterator().next().schema().getDimName());
   }
 
   @Test

--- a/core/src/test/scala/com/metamx/tranquility/test/GenericTimeAndDimsPartitionerTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/GenericTimeAndDimsPartitionerTest.scala
@@ -1,0 +1,159 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.test
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.common.hash.Hashing
+import com.metamx.common.scala.Jackson
+import com.metamx.common.scala.untyped.Dict
+import com.metamx.tranquility.druid.DruidRollup
+import com.metamx.tranquility.druid.SpecificDruidDimensions
+import com.metamx.tranquility.partition.GenericTimeAndDimsPartitioner
+import com.metamx.tranquility.typeclass.Timestamper
+import io.druid.data.input.impl.TimestampSpec
+import io.druid.granularity.QueryGranularity
+import io.druid.query.aggregation.DoubleSumAggregatorFactory
+import java.{util => ju}
+import org.joda.time.DateTime
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+class GenericTimeAndDimsPartitionerTest extends FunSuite with Matchers
+{
+  val same = Seq(
+    Dict("t" -> new DateTime("2000T00:00:03"), "foo" -> 1, "bar" -> Seq("y", "z")),
+    Dict("t" -> new DateTime("2000T00:00:03"), "foo" -> 1, "bar" -> Seq("z", "y", "")),
+    Dict("t" -> new DateTime("2000T00:00:04"), "foo" -> Seq(1), "bar" -> Seq("z", "y"), "baz" -> Nil),
+    Dict("t" -> new DateTime("2000T00:00:05"), "foo" -> 1, "bar" -> Seq("y", "z"), "baz" -> ""),
+    Dict("t" -> new DateTime("2000T00:00:06"), "foo" -> 1, "bar" -> Seq("y", "z"), "baz" -> null),
+    Dict("t" -> new DateTime("2000T00:00:06"), "foo" -> "1", "bar" -> Seq("y", "z"), "baz" -> null),
+    Dict("t" -> new DateTime("2000T00:00:06"), "foo" -> Seq("1"), "bar" -> Seq("z", "y"))
+  )
+
+  val different = Seq(
+    Dict("t" -> new DateTime("2000T00:00:03"), "foo" -> 1, "bar" -> Seq("y", "z"), "baz" -> "buh"),
+    Dict("t" -> new DateTime("2000T00:01:03"), "foo" -> 1, "bar" -> Seq("y", "z")),
+    Dict("t" -> new DateTime("2000T00:00:03"), "bar" -> Seq("y", "z")),
+    Dict("t" -> new DateTime("2000T00:00:03"), "foo" -> 2, "bar" -> Seq("y", "z")),
+    Dict("t" -> new DateTime("2000T00:00:03"), "foo" -> "3", "bar" -> Seq("y", "z")),
+    Dict("t" -> new DateTime("2000T00:00:06"), "foo" -> Seq("1"), "bar" -> "y"),
+    Dict("t" -> new DateTime("2000T00:00:06"), "foo" -> Seq("1"), "bar" -> "z"),
+    Dict("t" -> new DateTime("2000T00:00:06"), "foo" -> Seq("1"), "bar" -> Seq("y", "z", "x")),
+    Dict("t" -> new DateTime("2000T00:00:06"), "foo" -> Seq("1"), "bar" -> Seq("z", "x"))
+  )
+
+  test("Scala Map") {
+    val timestamper = new Timestamper[Dict] {
+      override def timestamp(a: Dict): DateTime = new DateTime(a("t"))
+    }
+    val partitioner = GenericTimeAndDimsPartitioner.create(
+      timestamper,
+      new TimestampSpec("t", "auto", null),
+      DruidRollup(
+        SpecificDruidDimensions(Seq("foo", "bar", "baz")),
+        Seq(new DoubleSumAggregatorFactory("x", "xSum")),
+        QueryGranularity.MINUTE
+      )
+    )
+
+    for (x <- same; y <- same) {
+      val xPartition = partitioner.partition(x, Int.MaxValue)
+      val yPartition = partitioner.partition(y, Int.MaxValue)
+      xPartition should be(yPartition)
+    }
+
+    for (x <- same; y <- different) {
+      val xPartition = partitioner.partition(x, Int.MaxValue)
+      val yPartition = partitioner.partition(y, Int.MaxValue)
+
+      // Could have false positives, but it's not likely
+      xPartition shouldNot be(yPartition)
+    }
+
+    for ((x, i) <- different.zipWithIndex; y <- different.drop(i + 1)) {
+      val xPartition = partitioner.partition(x, Int.MaxValue)
+      val yPartition = partitioner.partition(y, Int.MaxValue)
+
+      // Could have false positives, but it's not likely
+      xPartition shouldNot be(yPartition)
+    }
+  }
+
+  test("Java Map") {
+    val timestamper = new Timestamper[ju.Map[String, Any]] {
+      override def timestamp(a: ju.Map[String, Any]): DateTime = new DateTime(a.get("t"))
+    }
+    val partitioner = GenericTimeAndDimsPartitioner.create(
+      timestamper,
+      new TimestampSpec("t", "auto", null),
+      DruidRollup(
+        SpecificDruidDimensions(Seq("foo", "bar", "baz")),
+        Seq(new DoubleSumAggregatorFactory("x", "xSum")),
+        QueryGranularity.MINUTE
+      )
+    )
+
+    val sameJava: Seq[ju.Map[String, Any]] = same map javaCopy
+    val differentJava: Seq[ju.Map[String, Any]] = different map javaCopy
+
+    for (x <- sameJava; y <- sameJava) {
+      val xPartition = partitioner.partition(x, Int.MaxValue)
+      val yPartition = partitioner.partition(y, Int.MaxValue)
+      xPartition should be(yPartition)
+    }
+
+    for (x <- sameJava; y <- differentJava) {
+      val xPartition = partitioner.partition(x, Int.MaxValue)
+      val yPartition = partitioner.partition(y, Int.MaxValue)
+
+      // Could have false positives, but it's not likely
+      xPartition shouldNot be(yPartition)
+    }
+
+    for ((x, i) <- differentJava.zipWithIndex; y <- differentJava.drop(i + 1)) {
+      val xPartition = partitioner.partition(x, Int.MaxValue)
+      val yPartition = partitioner.partition(y, Int.MaxValue)
+
+      // Could have false positives, but it's not likely
+      xPartition shouldNot be(yPartition)
+    }
+  }
+
+  test("String") {
+    val timestamper = new Timestamper[String] {
+      override def timestamp(a: String): DateTime = new DateTime(1000)
+    }
+    val partitioner = GenericTimeAndDimsPartitioner.create(
+      timestamper,
+      new TimestampSpec("t", "auto", null),
+      DruidRollup(
+        SpecificDruidDimensions(Seq("foo", "bar", "baz")),
+        Seq(new DoubleSumAggregatorFactory("x", "xSum")),
+        QueryGranularity.MINUTE
+      )
+    )
+
+    partitioner.partition("foo", Int.MaxValue) should be(Hashing.consistentHash("foo".hashCode, Int.MaxValue))
+  }
+
+  private def javaCopy(d: Dict): ju.Map[String, Any] = {
+    new ObjectMapper().readValue(Jackson.bytes(d), classOf[ju.Map[String, Any]])
+  }
+}

--- a/core/src/test/scala/com/metamx/tranquility/test/HashPartitionBeamTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/HashPartitionBeamTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.test
+
+import com.metamx.tranquility.beam.Beam
+import com.metamx.tranquility.beam.HashPartitionBeam
+import com.twitter.util.Await
+import com.twitter.util.Future
+import java.util.concurrent.CopyOnWriteArrayList
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+
+class HashPartitionBeamTest extends FunSuite with Matchers
+{
+
+  class TestObject(val s: String)
+  {
+    override def hashCode(): Int = s(0).toInt
+  }
+
+  class TestBeam(callback: TestObject => Unit) extends Beam[TestObject]
+  {
+    override def propagate(events: Seq[TestObject]): Future[Int] = {
+      events foreach callback
+      Future(events.size)
+    }
+
+    override def close() = Future.Done
+  }
+
+  test("Partitioning") {
+    val bufferOne: mutable.Buffer[TestObject] = new CopyOnWriteArrayList[TestObject]().asScala
+    val bufferTwo: mutable.Buffer[TestObject] = new CopyOnWriteArrayList[TestObject]().asScala
+
+    val one = new TestBeam(bufferOne += _)
+    val two = new TestBeam(bufferTwo += _)
+    val beam = new HashPartitionBeam(Vector(one, two))
+    Await.result(
+      beam.propagate(
+        Seq(
+          new TestObject("foo"),
+          new TestObject("bar"),
+          new TestObject("foo")
+        )
+      )
+    ) should be(3)
+    bufferOne.map(_.s) should be(Seq("bar"))
+    bufferTwo.map(_.s) should be(Seq("foo", "foo"))
+  }
+}


### PR DESCRIPTION
The default partitioning only works properly for Maps because other types are actually opaque
to tranquility (it doesn't know how the ObjectWriter is going to serialize them). But, you can
provide your own Partitioner (or an entire beamMergeFn, which you could already do).

Fixes #6.