### PR TITLE
tranquility-kafka module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Modules:
 - [Samza](docs/samza.md) - Tranquility includes a Samza SystemProducer.
 - [Spark](docs/spark.md) - Tranquility works with RDDs and DStreams.
 - [Storm](docs/storm.md) - Tranquility includes a Storm Bolt and a Trident State.
+- [Kafka](docs/kafka.md) - Application to push messages from Kafka into Druid through Tranquility.
 
 ### Getting Tranquility with Maven
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,8 @@ val sparkVersion = "1.6.0"
 val scalatraVersion = "2.3.1"
 val jettyVersion = "9.2.5.v20141112"
 val apacheHttpVersion = "4.3.3"
+val kafkaVersion = "0.9.0.0"
+val airlineVersion = "0.7"
 
 def dependOnDruid(artifact: String) = {
   ("io.druid" % artifact % druidVersion
@@ -100,13 +102,21 @@ val serverDependencies = Seq(
   "org.eclipse.jetty" % "jetty-servlet" % jettyVersion
 ) ++ loggingDependencies
 
+val kafkaDependencies = Seq(
+  "org.apache.kafka" %% "kafka" % kafkaVersion
+    exclude("org.slf4j", "slf4j-log4j12")
+    exclude("log4j", "log4j")
+    force(),
+  "io.airlift" % "airline" % airlineVersion
+) ++ loggingDependencies
+
 val coreTestDependencies = Seq(
   "org.scalatest" %% "scalatest" % "2.2.5" % "test",
   dependOnDruid("druid-services") % "test",
   "org.apache.curator" % "curator-test" % "2.6.0" % "test" exclude("log4j", "log4j") force(),
   "com.sun.jersey" % "jersey-servlet" % "1.17.1" % "test" force(),
-  "junit" % "junit" % "4.11" % "test",
-  "com.novocode" % "junit-interface" % "0.11-RC1" % "test",
+  "junit" % "junit" % "4.12" % "test",
+  "com.novocode" % "junit-interface" % "0.11" % "test",
   "ch.qos.logback" % "logback-core" % "1.1.2" % "test",
   "ch.qos.logback" % "logback-classic" % "1.1.2" % "test",
   "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.4" % "test",
@@ -123,6 +133,10 @@ val samzaTestDependencies = Seq(
 
 val serverTestDependencies = Seq(
   "org.scalatra" %% "scalatra-test" % scalatraVersion % "test"
+)
+
+val kafkaTestDependencies = Seq(
+  "org.easymock" % "easymock" % "3.4" % "test"
 )
 
 lazy val commonSettings = Seq(
@@ -164,7 +178,7 @@ lazy val commonSettings = Seq(
 lazy val root = project.in(file("."))
   .settings(commonSettings: _*)
   .settings(publishArtifact := false)
-  .aggregate(core, storm, samza, spark, server)
+  .aggregate(core, storm, samza, spark, server, kafka)
 
 lazy val core = project.in(file("core"))
   .settings(commonSettings: _*)
@@ -201,6 +215,15 @@ lazy val server = project.in(file("server"))
   .settings(name := "tranquility-server")
   .settings(libraryDependencies ++= (serverDependencies ++ serverTestDependencies))
   .settings(publishArtifact in Test := false)
+  .dependsOn(core % "test->test;compile->compile")
+
+lazy val kafka = project.in(file("kafka"))
+  .settings(commonSettings: _*)
+  .settings(name := "tranquility-kafka")
+  .settings(libraryDependencies ++= (kafkaDependencies ++ kafkaTestDependencies))
+  .settings(publishArtifact in Test := false)
+  .settings(javaOptions in Universal ++= Seq("-J-Dfile.encoding=UTF-8", "-J-Duser.timezone=UTC"))
+  .enablePlugins(JavaAppPackaging)
   .dependsOn(core % "test->test;compile->compile")
 
 lazy val distribution = project.in(file("distribution"))

--- a/core/src/main/scala/com/metamx/tranquility/config/ConfigHelper.scala
+++ b/core/src/main/scala/com/metamx/tranquility/config/ConfigHelper.scala
@@ -1,0 +1,143 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.config
+
+import com.metamx.common.scala.Predef._
+import com.metamx.common.scala.Yaml
+import com.metamx.common.scala.untyped._
+import com.metamx.tranquility.druid.DruidBeams
+import com.metamx.tranquility.druid.DruidEnvironment
+import com.metamx.tranquility.druid.DruidGuicer
+import com.metamx.tranquility.druid.DruidLocation
+import com.metamx.tranquility.finagle.FinagleRegistry
+import com.metamx.tranquility.tranquilizer.Tranquilizer
+import io.druid.segment.realtime.FireDepartment
+import java.io.InputStream
+import java.util.Properties
+import org.apache.curator.framework.CuratorFramework
+import org.skife.config.ConfigurationObjectFactory
+
+/**
+ * Helper methods to perform shared tasks based on common configuration file semantics.
+ */
+object ConfigHelper
+{
+  /**
+   * Builds configuration object from YAML file.
+   *
+   * This method may have the side effect of modifying system properties if the YAML file contains properties beginning
+   * with "druid.extensions." - this is necessary as DruidGuicer reads the system properties to know what extensions
+   * need to be loaded. If the properties have already been set elsewhere, the system properties will not be modified.
+   */
+  def readConfigYaml[T <: TranquilityConfig](
+    in: InputStream,
+    clazz: Class[T]
+    ): (T, Map[String, DataSourceConfig[T]], Dict) =
+  {
+    val yaml = in.withFinally(_.close()) { in =>
+      dict(Yaml.load(in))
+    }
+    val globalProperties: Dict = getAsDict(yaml, "properties")
+    val globalConfig = mapConfig(globalProperties, clazz)
+
+    for (prop <- globalProperties.filterKeys(_.startsWith("druid.extensions.")))
+    {
+      if (!sys.props.contains(prop._1)) {
+        // copy properties to system as DruidGuicer reads system properties to know what extensions need to be loaded
+        sys.props += (prop._1 -> prop._2.toString)
+      }
+    }
+
+    val dataSources: Dict = getAsDict(yaml, "dataSources")
+    val dataSourceConfigs = for ((dataSource, x) <- dataSources) yield {
+      val d = dict(x)
+      val dataSourceProperties = getAsDict(d, "properties")
+      for (k <- globalConfig.GlobalProperties) {
+        require(!dataSourceProperties.contains(k), s"Property '$k' cannot be per-dataSource (found in[$dataSource]).")
+      }
+
+      val dataSourceSpec = getAsDict(d, "spec")
+      val fireDepartment = DruidGuicer.objectMapper.convertValue(normalizeJava(dataSourceSpec), classOf[FireDepartment])
+      val config = mapConfig(globalProperties ++ dataSourceProperties, clazz)
+
+      // Sanity check: two ways of providing dataSource, they must match
+      require(
+        dataSource == fireDepartment.getDataSchema.getDataSource,
+        s"dataSource[$dataSource] did not match spec[${fireDepartment.getDataSchema.getDataSource}]"
+      )
+
+      (dataSource, DataSourceConfig(config, fireDepartment))
+    }
+
+    (globalConfig, dataSourceConfigs, globalProperties)
+  }
+
+  private def mapConfig[A](d: Dict, clazz: Class[A]): A = {
+    val properties = new Properties
+    for ((k, v) <- d if v != null) {
+      properties.setProperty(k, String.valueOf(v))
+    }
+    val configFactory = new ConfigurationObjectFactory(properties)
+    configFactory.build(clazz)
+  }
+
+  private def getAsDict(d: Dict, k: String): Dict = {
+    Option(d.getOrElse(k, null)).map(dict(_)).getOrElse(Dict())
+  }
+
+  def createTranquilizer[T <: TranquilityConfig](
+    dataSourceConfig: DataSourceConfig[T],
+    finagleRegistry: FinagleRegistry,
+    curator: CuratorFramework
+    ): Tranquilizer[Dict] =
+  {
+    createTranquilizerWithLocation(dataSourceConfig, finagleRegistry, curator, null)
+  }
+
+  def createTranquilizerWithLocation[T <: TranquilityConfig](
+    dataSourceConfig: DataSourceConfig[T],
+    finagleRegistry: FinagleRegistry,
+    curator: CuratorFramework,
+    location: DruidLocation
+    ): Tranquilizer[Dict] =
+  {
+    val environment = DruidEnvironment(dataSourceConfig.config.druidIndexingServiceName)
+
+    // Create beam for this dataSource
+    var beamBuilder = DruidBeams
+      .builder(environment, dataSourceConfig.fireDepartment)
+      .curator(curator)
+      .finagleRegistry(finagleRegistry)
+      .partitions(dataSourceConfig.config.taskPartitions)
+      .replicants(dataSourceConfig.config.taskReplicants)
+      .druidBeamConfig(dataSourceConfig.config.druidBeamConfig)
+
+    if (location != null) {
+      beamBuilder = beamBuilder.location(location)
+    }
+
+    Tranquilizer(
+      beamBuilder.buildBeam(),
+      dataSourceConfig.config.tranquilityMaxBatchSize,
+      dataSourceConfig.config.tranquilityMaxPendingBatches,
+      dataSourceConfig.config.tranquilityLingerMillis
+    )
+  }
+}

--- a/core/src/main/scala/com/metamx/tranquility/config/config.scala
+++ b/core/src/main/scala/com/metamx/tranquility/config/config.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.config
+
+import com.metamx.common.scala.net.curator.DiscoAnnounceConfig
+import com.metamx.common.scala.net.curator.DiscoConfig
+import com.metamx.tranquility.beam.ClusteredBeamTuning
+import com.metamx.tranquility.druid.DruidBeamConfig
+import com.metamx.tranquility.tranquilizer.Tranquilizer
+import io.druid.segment.realtime.FireDepartment
+import org.joda.time.Period
+import org.skife.config.Config
+
+abstract class TranquilityConfig(globalProperties: Set[String]) extends DiscoConfig
+{
+  def this() {
+    this(Set[String]())
+  }
+
+  val GlobalProperties = Set[String]() ++ globalProperties
+
+  @Config(Array("druid.selectors.indexing.serviceName"))
+  def druidIndexingServiceName: String = "druid/overlord"
+
+  @Config(Array("task.partitions"))
+  def taskPartitions: Int = ClusteredBeamTuning().partitions
+
+  @Config(Array("task.replicants"))
+  def taskReplicants: Int = ClusteredBeamTuning().replicants
+
+  @Config(Array("task.warmingPeriod"))
+  def taskWarmingPeriod: Period = ClusteredBeamTuning().warmingPeriod
+
+  @Config(Array("zookeeper.connect"))
+  def zookeeperConnect: String
+
+  @Config(Array("zookeeper.timeout"))
+  def zookeeperTimeout: Period = new Period("PT20S")
+
+  @Config(Array("tranquility.maxBatchSize"))
+  def tranquilityMaxBatchSize: Int = Tranquilizer.DefaultMaxBatchSize
+
+  @Config(Array("tranquility.maxPendingBatches"))
+  def tranquilityMaxPendingBatches: Int = Tranquilizer.DefaultMaxPendingBatches
+
+  @Config(Array("tranquility.lingerMillis"))
+  def tranquilityLingerMillis: Int = Tranquilizer.DefaultLingerMillis
+
+  @Config(Array("druid.discovery.curator.path"))
+  def discoPath: String = "/druid/discovery"
+
+  @Config(Array("druidBeam.firehoseGracePeriod"))
+  def firehoseGracePeriod: Period = DruidBeamConfig().firehoseGracePeriod
+
+  @Config(Array("druidBeam.firehoseQuietPeriod"))
+  def firehoseQuietPeriod: Period = DruidBeamConfig().firehoseQuietPeriod
+
+  @Config(Array("druidBeam.firehoseRetryPeriod"))
+  def firehoseRetryPeriod: Period = DruidBeamConfig().firehoseRetryPeriod
+
+  @Config(Array("druidBeam.firehoseChunkSize"))
+  def firehoseChunkSize: Int = DruidBeamConfig().firehoseChunkSize
+
+  @Config(Array("druidBeam.randomizeTaskId"))
+  def randomizeTaskId: Boolean = DruidBeamConfig().randomizeTaskId
+
+  @Config(Array("druidBeam.indexRetryPeriod"))
+  def indexRetryPeriod: Period = DruidBeamConfig().indexRetryPeriod
+
+  @Config(Array("druidBeam.firehoseBufferSize"))
+  def firehoseBufferSize: Int = DruidBeamConfig().firehoseBufferSize
+
+  def druidBeamConfig: DruidBeamConfig = DruidBeamConfig.builder()
+    .firehoseGracePeriod(firehoseGracePeriod)
+    .firehoseQuietPeriod(firehoseQuietPeriod)
+    .firehoseRetryPeriod(firehoseRetryPeriod)
+    .firehoseChunkSize(firehoseChunkSize)
+    .randomizeTaskId(randomizeTaskId)
+    .indexRetryPeriod(indexRetryPeriod)
+    .firehoseBufferSize(firehoseBufferSize)
+    .build()
+
+  override def discoAnnounce: Option[DiscoAnnounceConfig] = None
+}
+
+case class DataSourceConfig[T <: TranquilityConfig](config: T, fireDepartment: FireDepartment)

--- a/core/src/test/resources/tranquility-core.yaml
+++ b/core/src/test/resources/tranquility-core.yaml
@@ -1,0 +1,39 @@
+dataSources:
+  foo:
+    spec:
+      dataSchema:
+        dataSource: foo
+        parser:
+          type: string
+          parseSpec:
+            format: json
+            timestampSpec:
+              column: timestamp
+              format: auto
+            dimensionsSpec:
+              dimensions: [dim1, dim2, dim3]
+
+        metricsSpec:
+          - { type: count, name: count }
+          - { type: doubleSum, name: x, fieldName: x }
+
+        granularitySpec:
+          type: uniform
+          segmentGranularity: hour
+          queryGranularity: none
+
+      ioConfig:
+        type: realtime
+
+      tuningConfig:
+        type: realtime
+        maxRowsInMemory: 100000
+        intermediatePersistPeriod: PT45S
+        windowPeriod: PT30S
+
+    properties:
+      task.partitions: 3
+
+properties:
+  task.partitions: 2
+  zookeeper.connect: zk.example.com

--- a/core/src/test/scala/com/metamx/tranquility/test/ConfigHelperTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/ConfigHelperTest.scala
@@ -17,22 +17,20 @@
  * under the License.
  */
 
-package com.metamx.tranquility.server
+package com.metamx.tranquility.test
 
-import com.metamx.tranquility.server.http.ServerMain
+import com.metamx.tranquility.config.ConfigHelper
+import com.metamx.tranquility.config.TranquilityConfig
 import org.joda.time.Period
 import org.scalatest.FunSuite
 import org.scalatest.ShouldMatchers
 
-class ServerMainTest extends FunSuite with ShouldMatchers
+class ConfigHelperTest extends FunSuite with ShouldMatchers
 {
   test("readConfigYaml") {
-    val (globalConfig, dataSourceConfigs) = ServerMain.readConfigYaml(
-      getClass.getClassLoader.getResourceAsStream("tranquility-server.yaml")
+    val (globalConfig, dataSourceConfigs, globalProperties) = ConfigHelper.readConfigYaml(
+      getClass.getClassLoader.getResourceAsStream("tranquility-core.yaml"), classOf[TranquilityConfig]
     )
-
-    globalConfig.httpPort should be(8080)
-    globalConfig.httpThreads should be(2)
 
     dataSourceConfigs.keySet should be(Set("foo"))
 
@@ -44,6 +42,6 @@ class ServerMainTest extends FunSuite with ShouldMatchers
     fooConfig.fireDepartment.getTuningConfig.getWindowPeriod should be(new Period("PT30S"))
     fooConfig.config.zookeeperConnect should be("zk.example.com")
     fooConfig.config.taskPartitions should be(3)
-    fooConfig.config.druidBeamConfig.firehoseGracePeriod should be(new Period("PT1S"))
+    fooConfig.config.druidBeamConfig.firehoseGracePeriod should be(new Period("PT5M"))
   }
 }

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -1,0 +1,147 @@
+# Kafka
+
+Tranquility Kafka is an application which simplifies the ingestion of data from Kafka. It is scalable and highly
+available through the use of Kafka partitions and consumer groups, and can be configured to push data from multiple
+Kafka topics into multiple Druid dataSources.
+
+## Setup
+
+### Getting Tranquility Kafka
+
+Tranquility Kafka currently must be built from source. To build, run `sbt universal:packageZipTarball`. The build output
+will be contained in the archive `/kafka/target/universal/tranquility-kafka-x.x.x.tgz`. Unpack this tarball to the
+directory of choice by running `tar -xzf tranquility-kafka-x-x-x.tgz`.
+
+### Configuration
+
+Tranquility Kafka uses a YAML file for configuration. You can see an example in `conf/tranquility-kafka.yaml.example` of the
+tarball distribution. You can start off your installation by copying this example file to `conf/tranquility-kafka.yaml`. The
+YAML file has two sections:
+
+1. `dataSources` - per dataSource configuration.
+2. `properties` - general properties that apply to all dataSources. See "Configuration reference" for details.
+
+The dataSources key should contain a mapping of dataSource name to configuration. Each dataSource configuration
+has two sections:
+
+1. `spec` - a YAML representation of a [Druid ingestion spec](http://druid.io/docs/latest/ingestion/index.html). Note
+that the `ioConfig` is expected to be of type `realtime` but otherwise empty (null firehose, null plumber). This is
+because Tranquility supplies its own firehose and plumber.
+2. `properties` - per dataSource properties. See "Configuration reference" for details.
+
+### Running
+
+If you've saved your configuration into `conf/tranquility-kafka.yaml`, run the application with:
+
+```bash
+bin/tranquility-kafka -configFile conf/tranquility-kafka.yaml
+```
+
+## Configuration reference
+
+With the exception of the global properties (which must be provided at the top level), most properties can be provided
+at the top level or per-dataSource. If the same property is provided at both levels, the per-dataSource version will
+take precedence. This provides a way to set default properties that apply to all dataSources, while still allowing
+customization for certain dataSources.
+
+### Global properties
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`kafka.zookeeper.connect`|ZooKeeper connect string for Kafka.|none; must be provided|
+|`kafka.group.id`|Group ID for Kafka consumers. **Note:** This must be the same for all instances to avoid data duplication!|tranquility-kafka|
+|`consumer.numThreads`|The number of threads that will be made available to the Kafka consumer for fetching messages.|{numProcessors} - 1|
+|`commit.periodMillis`|The frequency with which consumer offsets will be committed to ZooKeeper to track processed messages.|15000|
+|`kafka.*`|Any properties that begin with *kafka.* will be passed to the underlying Kafka consumer with the *kafka.* prefix removed. For example, if you set `kafka.consumer.id=myConsumer`, the Kafka consumer will be passed the property `consumer.id=myConsumer`. Note that Tranquility Kafka requires `auto.commit.enable` to be *false* and any attempt to set this property will be overridden. |none|
+|`druid.extensions.*`|You may load Druid extensions into Tranquility Kafka using the extension properties defined on the Druid [common configuration](http://druid.io/docs/latest/configuration/index.html) page. This is required if your dataSource configuration contains fields not part of core Druid such as *approxHistogram*. As an example, to load the histogram extension, set `druid.extensions.coordinates: "[\"io.druid.extensions:druid-histogram:x.x.x\"]"`.|none|
+
+### Other properties
+
+|Property|Description|Default|
+|--------|-----------|-------|
+|`druid.discovery.curator.path`|Curator service discovery path.|/druid/discovery|
+|`druid.selectors.indexing.serviceName`|The druid.service name of the indexing service Overlord node.|druid/overlord|
+|`topicPattern`|A regular expression used to match Kafka topics to dataSource configurations. See "Matching Topics to Data Sources" for details.|{match nothing}, must be provided|
+|`topicPattern.priority`|If multiple topicPatterns match the same topic name, the highest priority dataSource configuration will be used. A higher number indicates a higher priority. See "Matching Topics to Data Sources" for details.|1|
+|`useTopicAsDataSource`|Use the Kafka topic as the dataSource name instead of the one provided in the YAML. Useful when combined with a topicPattern that matches more than one Kafka topic. See "Matching Topics to Data Sources" for details.|false|
+|`reportDropsAsExceptions`|Whether or not dropped messages will cause an exception and terminate the application.|false|
+|`task.partitions`|Number of Druid partitions to create.|1|
+|`task.replicants`|Number of instances of each Druid partition to create. This is the *total* number of instances, so 2 replicants means 2 tasks will be created.|1|
+|`task.warmingPeriod`|If nonzero, create Druid tasks early. This can be useful if tasks take a long time to start up in your environment.|PT0M|
+|`zookeeper.connect`|ZooKeeper connect string.|none; must be provided|
+|`zookeeper.timeout`|ZooKeeper session timeout. ISO8601 duration.|PT20S|
+|`tranquility.maxBatchSize`|Maximum number of messages to send at once.|2000|
+|`tranquility.maxPendingBatches`|Maximum number of batches that may be in flight before we block and wait for one to finish.|5|
+|`tranquility.lingerMillis`|Wait this long for batches to collect more messages (up to maxBatchSize) before sending them. Set to zero to disable waiting.|0|
+|`druidBeam.firehoseGracePeriod`|Druid indexing tasks will shut down this long after the windowPeriod has elapsed.|PT5M|
+|`druidBeam.firehoseQuietPeriod`|Wait this long for a task to appear before complaining that it cannot be found.|PT1M|
+|`druidBeam.firehoseRetryPeriod`|Retry for this long before complaining that events could not be pushed|PT1M|
+|`druidBeam.firehoseChunkSize`|Maximum number of events to send to Druid in one HTTP request.|1000|
+|`druidBeam.randomizeTaskId`|True if we should add a random suffix to Druid task IDs. This is useful for testing.|false|
+|`druidBeam.indexRetryPeriod`|If an indexing service overlord call fails for some apparently-transient reason, retry for this long before giving up.|PT1M|
+|`druidBeam.firehoseBufferSize`|Size of buffer used by firehose to store events.|100000|
+
+
+## Matching Topics to Data Sources
+
+Tranquility Kafka supports matching multiple Kafka topics to Druid dataSources through the use of the regex-based
+`topicPattern` property. A topic can be mapped to at most one dataSource at a time; if there are multiple topic patterns
+that match a given Kafka topic, the one with the highest-valued `topicPattern.priority` will be used.
+
+This can be combined with the `useTopicAsDataSource` property to map multiple topics to multiple similar dataSources
+without having to add repeated configurations for each dataSource. When `useTopicAsDataSource` is set to `true`, the
+dataSource name for this entry will be ignored and the Kafka topic will be used instead. Since the `topicPattern`
+matches using regular expressions, this can be used to watch for Kafka topics that did not exist when the application
+was started and dynamically create new Druid dataSources with the topic as its name.
+
+As an example, consider the following configuration (unrelated properties removed for clarity):
+
+```
+dataSources:
+  wikipedia:
+    spec:
+      dataSchema:
+        dataSource: wikipedia
+    properties:
+      topicPattern: wikipedia
+      topicPattern.priority: 2
+
+  wikipedia-lang:
+    spec:
+      dataSchema:
+        dataSource: wikipedia-lang
+    properties:
+      topicPattern: wikipedia.*
+      useTopicAsDataSource: true
+```
+
+Given the list of Kafka topics *[wikipedia, wikipedia-fr, wikipedia-es]*:
+
+  - The topic *wikipedia* will be matched to the `wikipedia` configuration, even though it also matches `wikipedia-lang`
+  (order in the YAML does not matter) since `wikipedia` has a higher `topicPattern.priority` than `wikipedia-lang`
+  (which has the default priority of 1). This will be mapped to a dataSource named **wikipedia**.
+  - The topics *wikipedia-fr* and *wikipedia-es* will both be matched to `wikipedia-lang`. Since `useTopicAsDataSource`
+  is set to true, they will be mapped to dataSources named **wikipedia-fr** and **wikipedia-es** respectively and will
+  not be both mapped to a dataSource named **wikipedia-lang** (which is what would happen if `useTopicAsDataSource` was
+  false).
+  - In the future, if we were interested in *wikipedia-de* and created a new Kafka topic for it, this new topic would be
+   automatically discovered and matched to the `wikipedia-lang` configuration which will result in a new dataSource
+   **wikipedia-de** being created.
+
+
+## Deployment
+
+Multiple instances of Tranquility Kafka may be deployed to provide scalability (through each instance owning a subset
+of the Kafka partitions) and redundancy (through all instances sharing the same Kafka group ID). If the configuration
+changes, instances can be brought down and updated one at a time to update the cluster without any downtime.
+
+If the update was to add a new configuration, the first updated instance will begin receiving all the messages from the
+newly-mapped Kafka topics until subsequent instances are updated which will trigger a load rebalance. If the update was
+to change an existing Druid ingestion spec, the old specification will remain in effect for the remainder of the
+segmentGranularity period and the new ingestion spec will be applied to the indexing tasks handling the next segment.
+
+Be aware that changing the name of the dataSource a Kafka topic is mapped to via rolling update will cause some of the
+topic's partitions to be written to the old dataSource and some to be written to the new dataSource during the
+transition period. This may or may not be acceptable depending on your use case. For a clean transition, it is suggested
+that you stop all old instances of Tranquility Kafka before starting the set of new ones, allowing Kafka to buffer
+events that were received during the update period.

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/KafkaConsumer.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/KafkaConsumer.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.metamx.tranquility.kafka;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.metamx.common.logger.Logger;
+import com.metamx.tranquility.config.DataSourceConfig;
+import com.metamx.tranquility.kafka.model.MessageCounters;
+import com.metamx.tranquility.kafka.model.TranquilityKafkaConfig;
+import com.metamx.tranquility.kafka.writer.WriterController;
+import io.druid.concurrent.Execs;
+import kafka.consumer.Consumer;
+import kafka.consumer.ConsumerConfig;
+import kafka.consumer.KafkaStream;
+import kafka.consumer.TopicFilter;
+import kafka.consumer.Whitelist;
+import kafka.javaapi.consumer.ConsumerConnector;
+import kafka.message.MessageAndMetadata;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Spawns a number of threads to read messages from Kafka topics and write them by calling
+ * WriterController.getWriter(topic).send(). Will periodically call WriterController.flushAll() and when this completes
+ * will call ConsumerConnector.commitOffsets() to save the last written offset to ZooKeeper. This implementation
+ * guarantees that any events in Kafka will be read at least once even in case of a failure condition but does not
+ * guarantee that duplication will not occur.
+ */
+public class KafkaConsumer
+{
+  private static final Logger log = new Logger(KafkaConsumer.class);
+
+  private final ExecutorService consumerExec;
+  private final Thread commitThread;
+  private final AtomicBoolean shutdown = new AtomicBoolean();
+
+  // prevents reading the next event from Kafka while events are being flushed and offset is being committed to ZK
+  private final ReentrantReadWriteLock commitLock = new ReentrantReadWriteLock();
+
+  private final ConsumerConnector consumerConnector;
+  private final TopicFilter topicFilter;
+  private final int numThreads;
+  private final int commitMillis;
+  private final WriterController writerController;
+
+  private Map<String, MessageCounters> previousMessageCounters = new HashMap<>();
+
+  public KafkaConsumer(
+      final TranquilityKafkaConfig globalConfig,
+      final Properties kafkaProperties,
+      final Map<String, DataSourceConfig<TranquilityKafkaConfig>> dataSourceConfigs,
+      final WriterController writerController
+  )
+  {
+    this.consumerConnector = getConsumerConnector(kafkaProperties);
+    this.topicFilter = new Whitelist(buildTopicFilter(dataSourceConfigs));
+
+    log.info("Kafka topic filter [%s]", this.topicFilter);
+
+    int defaultNumThreads = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+    this.numThreads = globalConfig.getConsumerNumThreads() > 0
+                      ? globalConfig.getConsumerNumThreads()
+                      : defaultNumThreads;
+
+    this.commitMillis = globalConfig.getCommitPeriodMillis();
+    this.writerController = writerController;
+    this.consumerExec = Execs.multiThreaded(numThreads, "KafkaConsumer-%d");
+    this.commitThread = new Thread(createCommitRunnable());
+    this.commitThread.setName("KafkaConsumer-CommitThread");
+    this.commitThread.setDaemon(true);
+  }
+
+  public void start()
+  {
+    commitThread.start();
+    startConsumers();
+  }
+
+  public void stop()
+  {
+    if (shutdown.compareAndSet(false, true)) {
+      log.info("Shutting down - attempting to flush buffers and commit final offsets");
+
+      try {
+        commitLock.writeLock().lockInterruptibly(); // prevent Kafka from consuming any more events
+        try {
+          writerController.flushAll(); // try to flush the remaining events to Druid
+          writerController.stop();
+          consumerConnector.commitOffsets(); // update commit offset
+        }
+        finally {
+          commitLock.writeLock().unlock();
+          consumerConnector.shutdown();
+          commitThread.interrupt();
+          consumerExec.shutdownNow();
+        }
+      }
+      catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        Throwables.propagate(e);
+      }
+
+      log.info("Finished clean shutdown.");
+    }
+  }
+
+  public void join() throws InterruptedException
+  {
+    commitThread.join();
+  }
+
+  void commit() throws InterruptedException
+  {
+    commitLock.writeLock().lockInterruptibly();
+    try {
+      final long flushStartTime = System.currentTimeMillis();
+      final Map<String, MessageCounters> messageCounters = writerController.flushAll(); // blocks until complete
+
+      final long commitStartTime = System.currentTimeMillis();
+      consumerConnector.commitOffsets();
+
+      final long finishedTime = System.currentTimeMillis();
+      Map<String, MessageCounters> countsSinceLastCommit = new HashMap();
+      for (Map.Entry<String, MessageCounters> entry : messageCounters.entrySet()) {
+        countsSinceLastCommit.put(
+            entry.getKey(),
+            entry.getValue().difference(previousMessageCounters.get(entry.getKey()))
+        );
+      }
+
+      previousMessageCounters = messageCounters;
+
+      log.info(
+          "Flushed %s pending messages in %sms and committed offsets in %sms.",
+          countsSinceLastCommit.isEmpty() ? "0" : countsSinceLastCommit,
+          commitStartTime - flushStartTime,
+          finishedTime - commitStartTime
+      );
+    }
+    finally {
+      commitLock.writeLock().unlock();
+    }
+  }
+
+  private Runnable createCommitRunnable()
+  {
+    return new Runnable()
+    {
+      @Override
+      public void run()
+      {
+        long lastFlushTime = System.currentTimeMillis();
+        try {
+          while (!Thread.currentThread().isInterrupted()) {
+            Thread.sleep(Math.max(commitMillis - (System.currentTimeMillis() - lastFlushTime), 0));
+            commit();
+            lastFlushTime = System.currentTimeMillis();
+          }
+        }
+        catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          log.info("Commit thread interrupted.");
+        }
+        catch (Throwable e) {
+          log.error(e, "Commit thread failed!");
+          throw Throwables.propagate(e);
+        }
+        finally {
+          stop();
+        }
+      }
+    };
+  }
+
+  private void startConsumers()
+  {
+    final List<KafkaStream<byte[], byte[]>> kafkaStreams = consumerConnector.createMessageStreamsByFilter(
+        topicFilter,
+        numThreads
+    );
+
+    for (final KafkaStream<byte[], byte[]> kafkaStream : kafkaStreams) {
+      consumerExec.submit(
+          new Runnable()
+          {
+            @Override
+            public void run()
+            {
+              try {
+                final Iterator<MessageAndMetadata<byte[], byte[]>> kafkaIterator = kafkaStream.iterator();
+
+                while (kafkaIterator.hasNext()) {
+                  if (Thread.currentThread().isInterrupted()) {
+                    throw new InterruptedException();
+                  }
+
+                  // Kafka consumer treats messages as consumed and updates in-memory last offset when the message
+                  // is returned by next(). In order to guarantee at-least-once message delivery, we need to a) set
+                  // autocommit enable to false so the consumer will not automatically commit offsets to Zookeeper, and
+                  // b) synchronize calls of kafkaIterator.next() with the commit thread so that we don't read messages
+                  // and then call consumerConnector.commitOffsets() before those messages have been flushed through
+                  // Tranquility into the indexing service.
+                  commitLock.readLock().lockInterruptibly();
+
+                  try {
+                    MessageAndMetadata<byte[], byte[]> data = kafkaIterator.next();
+                    writerController.getWriter(data.topic()).send(data.message());
+                  }
+                  finally {
+                    commitLock.readLock().unlock();
+                  }
+                }
+              }
+              catch (InterruptedException e) {
+                log.info("Consumer thread interrupted.");
+              }
+              catch (Throwable e) {
+                log.error(e, "Exception: ");
+                throw Throwables.propagate(e);
+              }
+              finally {
+                stop();
+              }
+            }
+          }
+      );
+    }
+  }
+
+  private static ConsumerConnector getConsumerConnector(final Properties props)
+  {
+    props.setProperty("auto.commit.enable", "false");
+
+    final ConsumerConfig config = new ConsumerConfig(props);
+    Preconditions.checkState(!config.autoCommitEnable(), "autocommit must be off");
+
+    return Consumer.createJavaConsumerConnector(config);
+  }
+
+  private static String buildTopicFilter(Map<String, DataSourceConfig<TranquilityKafkaConfig>> dataSourceConfigs)
+  {
+    StringBuilder topicFilter = new StringBuilder();
+    for (Map.Entry<String, DataSourceConfig<TranquilityKafkaConfig>> entry : dataSourceConfigs.entrySet()) {
+      topicFilter.append(String.format("(%s)|", entry.getValue().config().getTopicPattern()));
+    }
+
+    return topicFilter.length() > 0 ? topicFilter.substring(0, topicFilter.length() - 1) : "";
+  }
+}

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/model/MessageCounters.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/model/MessageCounters.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.kafka.model;
+
+/**
+ * Used for passing received, sent, and failed message counts from SimpleTranquilizerAdapter.
+ */
+public class MessageCounters
+{
+  private final long receivedCount, sentCount, failedCount;
+
+  public MessageCounters(long receivedCount, long sentCount, long failedCount)
+  {
+    this.receivedCount = receivedCount;
+    this.sentCount = sentCount;
+    this.failedCount = failedCount;
+  }
+
+  public long getReceivedCount()
+  {
+    return this.receivedCount;
+  }
+
+  public long getSentCount()
+  {
+    return this.sentCount;
+  }
+
+  public long getFailedCount()
+  {
+    return this.failedCount;
+  }
+
+  public MessageCounters difference(MessageCounters subtrahend)
+  {
+    if (subtrahend == null) {
+      return this;
+    }
+
+    return new MessageCounters(
+        this.receivedCount - subtrahend.getReceivedCount(),
+        this.sentCount - subtrahend.getSentCount(),
+        this.failedCount - subtrahend.getFailedCount()
+    );
+  }
+
+  @Override
+  public String toString()
+  {
+    return String.format("{receivedCount=%s, sentCount=%s, failedCount=%s}", receivedCount, sentCount, failedCount);
+  }
+}

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/model/TranquilityKafkaConfig.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/model/TranquilityKafkaConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.kafka.model;
+
+import com.google.common.collect.Lists;
+import com.metamx.tranquility.config.TranquilityConfig;
+import org.skife.config.Config;
+import org.skife.config.Default;
+import scala.collection.JavaConversions;
+
+/**
+ * Configuration object which extends Tranquility configuration with Kafka specific parameters.
+ */
+public abstract class TranquilityKafkaConfig extends TranquilityConfig
+{
+  public TranquilityKafkaConfig()
+  {
+    super(
+        JavaConversions.asScalaBuffer(
+            Lists.newArrayList(
+                "kafka.group.id",
+                "kafka.zookeeper.connect",
+                "consumer.numThreads",
+                "commit.periodMillis"
+            )
+        ).toSet()
+    );
+  }
+
+  @Config("kafka.group.id")
+  @Default("tranquility-kafka")
+  public abstract String getKafkaGroupId();
+
+  @Config("kafka.zookeeper.connect")
+  public abstract String getKafkaZookeeperConnect();
+
+  @Config("consumer.numThreads")
+  @Default("-1")
+  public abstract Integer getConsumerNumThreads();
+
+  @Config("topicPattern")
+  @Default("(?!)")
+  public abstract String getTopicPattern();
+
+  @Config("useTopicAsDataSource")
+  @Default("false")
+  public abstract Boolean useTopicAsDataSource();
+
+  @Config("topicPattern.priority")
+  @Default("1")
+  public abstract Integer getTopicPatternPriority();
+
+  @Config("commit.periodMillis")
+  @Default("15000")
+  public abstract Integer getCommitPeriodMillis();
+
+  @Config("reportDropsAsExceptions")
+  @Default("false")
+  public abstract Boolean reportDropsAsExceptions();
+}

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/writer/TranquilityEventWriter.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/writer/TranquilityEventWriter.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.metamx.tranquility.kafka.writer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Throwables;
+import com.metamx.common.logger.Logger;
+import com.metamx.tranquility.config.ConfigHelper;
+import com.metamx.tranquility.config.DataSourceConfig;
+import com.metamx.tranquility.druid.DruidLocation;
+import com.metamx.tranquility.finagle.FinagleRegistry;
+import com.metamx.tranquility.kafka.model.MessageCounters;
+import com.metamx.tranquility.kafka.model.TranquilityKafkaConfig;
+import com.metamx.tranquility.tranquilizer.SimpleTranquilizerAdapter;
+import com.metamx.tranquility.tranquilizer.Tranquilizer;
+import org.apache.curator.framework.CuratorFramework;
+import scala.Predef;
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Pushes events to Druid through Tranquility using the SimpleTranquilizerAdapter.
+ */
+public class TranquilityEventWriter
+{
+  private static final Logger log = new Logger(TranquilityEventWriter.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final DataSourceConfig<TranquilityKafkaConfig> dataSourceConfig;
+  private final SimpleTranquilizerAdapter<scala.collection.immutable.Map<String, Object>> simpleTranquilizerAdapter;
+
+  private long rejectedLogCount = 0;
+
+  public TranquilityEventWriter(
+      String topic,
+      DataSourceConfig<TranquilityKafkaConfig> dataSourceConfig,
+      CuratorFramework curator,
+      FinagleRegistry finagleRegistry
+  )
+  {
+    this.dataSourceConfig = dataSourceConfig;
+
+    final Tranquilizer<scala.collection.immutable.Map<String, Object>> tranquilizer =
+        ConfigHelper.createTranquilizerWithLocation(
+            dataSourceConfig,
+            finagleRegistry,
+            curator,
+            DruidLocation.create(
+                dataSourceConfig.config().druidIndexingServiceName(),
+                dataSourceConfig.config().useTopicAsDataSource()
+                ? topic
+                : dataSourceConfig.fireDepartment().getDataSchema().getDataSource()
+            )
+        );
+
+    simpleTranquilizerAdapter = SimpleTranquilizerAdapter.wrap(
+        tranquilizer,
+        dataSourceConfig.config().reportDropsAsExceptions()
+    );
+
+    simpleTranquilizerAdapter.start();
+  }
+
+  public void send(byte[] message) throws InterruptedException
+  {
+    Map<String, Object> map;
+    try {
+      map = MAPPER.readValue(
+          message, new TypeReference<HashMap<String, Object>>()
+          {
+          }
+      );
+    }
+    catch (IOException e) {
+      if (++rejectedLogCount <= 5
+          || (rejectedLogCount <= 100 && rejectedLogCount % 10 == 0)
+          || rejectedLogCount % 100 == 0) {
+        log.debug(e, "%d message(s) failed to parse as JSON and were rejected", rejectedLogCount);
+      }
+      if (dataSourceConfig.config().reportDropsAsExceptions()) {
+        Throwables.propagate(e);
+      }
+
+      return;
+    }
+
+    // this call may throw an exception for an unrelated message due to SimpleTranquilizerAdapter's implementation
+    simpleTranquilizerAdapter.send(
+        JavaConverters.mapAsScalaMapConverter(map).asScala().toMap(
+            Predef.<Tuple2<String, Object>>conforms()
+        )
+    );
+  }
+
+  public void flush() throws InterruptedException
+  {
+    simpleTranquilizerAdapter.flush();
+  }
+
+  public void stop()
+  {
+    try {
+      simpleTranquilizerAdapter.stop();
+    }
+    catch (IllegalStateException e) {
+      log.info(e, "Exception while stopping Tranquility");
+    }
+  }
+
+  public MessageCounters getMessageCounters()
+  {
+    return new MessageCounters(
+        simpleTranquilizerAdapter.receivedCount(),
+        simpleTranquilizerAdapter.sentCount(),
+        simpleTranquilizerAdapter.failedCount()
+    );
+  }
+}

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/writer/WriterController.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/writer/WriterController.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.metamx.tranquility.kafka.writer;
+
+import com.google.common.primitives.Ints;
+import com.metamx.common.logger.Logger;
+import com.metamx.common.scala.net.curator.Disco;
+import com.metamx.tranquility.config.DataSourceConfig;
+import com.metamx.tranquility.finagle.FinagleRegistry;
+import com.metamx.tranquility.finagle.FinagleRegistryConfig;
+import com.metamx.tranquility.kafka.model.MessageCounters;
+import com.metamx.tranquility.kafka.model.TranquilityKafkaConfig;
+import org.apache.curator.RetryPolicy;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.ExponentialBackoffRetry;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+/**
+ * Manages the creation and operation of TranquilityEventWriters.
+ */
+public class WriterController
+{
+  private static final Logger log = new Logger(WriterController.class);
+  private static final RetryPolicy RETRY_POLICY = new ExponentialBackoffRetry(1000, 500, 30000);
+
+  private List<DataSourceConfig<TranquilityKafkaConfig>> dataSourceConfigList;
+  private Map<String, TranquilityEventWriter> writers = new ConcurrentHashMap<>();
+  private Map<String, CuratorFramework> curators = new ConcurrentHashMap<>();
+  private Map<String, FinagleRegistry> finagleRegistries = new ConcurrentHashMap<>();
+
+  public WriterController(Map<String, DataSourceConfig<TranquilityKafkaConfig>> dataSourceConfigs)
+  {
+    this.dataSourceConfigList = new ArrayList<>(dataSourceConfigs.values());
+    this.dataSourceConfigList.sort(
+        new Comparator<DataSourceConfig<TranquilityKafkaConfig>>()
+        {
+          @Override
+          public int compare(DataSourceConfig<TranquilityKafkaConfig> o1, DataSourceConfig<TranquilityKafkaConfig> o2)
+          {
+            return o2.config().getTopicPatternPriority().compareTo(o1.config().getTopicPatternPriority());
+          }
+        }
+    );
+
+    log.info("Ready: [topicPattern] -> dataSource mappings:");
+    for (DataSourceConfig<TranquilityKafkaConfig> dataSourceConfig : this.dataSourceConfigList) {
+      log.info(
+          "  [%s] -> %s (priority: %d)",
+          dataSourceConfig.config().getTopicPattern(),
+          dataSourceConfig.fireDepartment().getDataSchema().getDataSource(),
+          dataSourceConfig.config().getTopicPatternPriority()
+      );
+    }
+  }
+
+  public synchronized TranquilityEventWriter getWriter(String topic)
+  {
+    if (!writers.containsKey(topic)) {
+      // create a EventWriter using the spec mapped to the first matching topicPattern
+      for (DataSourceConfig<TranquilityKafkaConfig> dataSourceConfig : dataSourceConfigList) {
+        if (Pattern.matches(dataSourceConfig.config().getTopicPattern(), topic)) {
+          log.info(
+              "Creating EventWriter for topic [%s] using dataSource [%s]",
+              topic,
+              dataSourceConfig.fireDepartment().getDataSchema().getDataSource()
+          );
+          writers.put(topic, createWriter(topic, dataSourceConfig));
+          return writers.get(topic);
+        }
+      }
+
+      throw new RuntimeException(String.format("Kafka topicFilter allowed topic [%s] but no spec is mapped", topic));
+    }
+
+    return writers.get(topic);
+  }
+
+  public Map<String, MessageCounters> flushAll() throws InterruptedException
+  {
+    Map<String, MessageCounters> flushedEvents = new HashMap<>();
+    for (Map.Entry<String, TranquilityEventWriter> entry : writers.entrySet()) {
+      flushedEvents.put(entry.getKey(), entry.getValue().getMessageCounters());
+      entry.getValue().flush();
+    }
+
+    return flushedEvents;
+  }
+
+  public void stop()
+  {
+    for (Map.Entry<String, TranquilityEventWriter> entry : writers.entrySet()) {
+      entry.getValue().stop();
+    }
+
+    for (Map.Entry<String, CuratorFramework> entry : curators.entrySet()) {
+      entry.getValue().close();
+    }
+  }
+
+  protected TranquilityEventWriter createWriter(String topic, DataSourceConfig<TranquilityKafkaConfig> dataSourceConfig)
+  {
+    final String curatorKey = dataSourceConfig.config().zookeeperConnect();
+    if (!curators.containsKey(curatorKey)) {
+      final int zkTimeout = Ints.checkedCast(
+          dataSourceConfig.config()
+                          .zookeeperTimeout()
+                          .toStandardDuration()
+                          .getMillis()
+      );
+
+      final CuratorFramework curator = CuratorFrameworkFactory.builder()
+                                                              .connectString(
+                                                                  dataSourceConfig.config()
+                                                                                  .zookeeperConnect()
+                                                              )
+                                                              .connectionTimeoutMs(zkTimeout)
+                                                              .retryPolicy(RETRY_POLICY)
+                                                              .build();
+      curator.start();
+      curators.put(curatorKey, curator);
+    }
+
+    final String finagleKey = String.format("%s:%s", curatorKey, dataSourceConfig.config().discoPath());
+    if (!finagleRegistries.containsKey(finagleKey)) {
+      finagleRegistries.put(
+          finagleKey, new FinagleRegistry(
+              FinagleRegistryConfig.builder().build(),
+              new Disco(curators.get(curatorKey), dataSourceConfig.config())
+          )
+      );
+    }
+
+    return new TranquilityEventWriter(
+        topic,
+        dataSourceConfig,
+        curators.get(curatorKey),
+        finagleRegistries.get(finagleKey)
+    );
+  }
+}

--- a/kafka/src/main/resources/logback.xml
+++ b/kafka/src/main/resources/logback.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Licensed to Metamarkets Group Inc. (Metamarkets) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  Metamarkets licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/kafka/src/test/java/com/metamx/tranquility/kafka/KafkaConsumerTest.java
+++ b/kafka/src/test/java/com/metamx/tranquility/kafka/KafkaConsumerTest.java
@@ -1,0 +1,334 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.io.Files;
+import com.metamx.tranquility.config.DataSourceConfig;
+import com.metamx.tranquility.kafka.model.MessageCounters;
+import com.metamx.tranquility.kafka.model.TranquilityKafkaConfig;
+import com.metamx.tranquility.kafka.writer.TranquilityEventWriter;
+import com.metamx.tranquility.kafka.writer.WriterController;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.segment.indexing.DataSchema;
+import io.druid.segment.indexing.RealtimeIOConfig;
+import io.druid.segment.indexing.RealtimeTuningConfig;
+import io.druid.segment.realtime.FireDepartment;
+import io.druid.segment.realtime.FireDepartmentMetrics;
+import io.druid.segment.realtime.firehose.LocalFirehoseFactory;
+import io.druid.segment.realtime.plumber.Plumber;
+import io.druid.segment.realtime.plumber.PlumberSchool;
+import junit.framework.Assert;
+import kafka.admin.AdminUtils;
+import kafka.common.OffsetMetadataAndError;
+import kafka.common.TopicAndPartition;
+import kafka.javaapi.OffsetFetchRequest;
+import kafka.javaapi.OffsetFetchResponse;
+import kafka.network.BlockingChannel;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServerStartable;
+import kafka.utils.ZkUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.curator.test.TestingServer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.easymock.EasyMock;
+import org.easymock.IAnswer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.skife.config.ConfigurationObjectFactory;
+
+import java.io.File;
+import java.net.ServerSocket;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+
+public class KafkaConsumerTest
+{
+  private static final String GROUP_ID = "test";
+  private static final String CLIENT_ID = "test";
+  private static final String MESSAGE = "message";
+
+  private static File tempDir;
+  private static TestingServer zk;
+  private static KafkaServerStartable kafka;
+  private static KafkaProducer<String, String> producer;
+  private static BlockingChannel channel;
+  private static Properties consumerProperties;
+  private static ZkUtils zkUtils;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception
+  {
+    tempDir = Files.createTempDir();
+    zk = new TestingServer();
+    kafka = new KafkaServerStartable(getKafkaTestConfig());
+    kafka.startup();
+
+    Properties props = new Properties();
+    props.put(
+        "bootstrap.servers",
+        String.format("%s:%s", kafka.serverConfig().hostName(), kafka.serverConfig().port())
+    );
+    producer = new KafkaProducer<>(props, new StringSerializer(), new StringSerializer());
+
+    channel = new BlockingChannel(
+        kafka.serverConfig().hostName(),
+        kafka.serverConfig().port(),
+        BlockingChannel.UseDefaultBufferSize(),
+        BlockingChannel.UseDefaultBufferSize(),
+        5000
+    );
+    channel.connect();
+
+    consumerProperties = new Properties();
+    consumerProperties.setProperty("group.id", GROUP_ID);
+    consumerProperties.setProperty("zookeeper.connect", zk.getConnectString());
+    consumerProperties.setProperty("kafka.zookeeper.connect", zk.getConnectString());
+
+    zkUtils = ZkUtils.apply(zk.getConnectString(), 5000, 5000, false);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception
+  {
+    channel.disconnect();
+    producer.close();
+    kafka.shutdown();
+    zk.close();
+    FileUtils.deleteDirectory(tempDir);
+  }
+
+  private static KafkaConfig getKafkaTestConfig() throws Exception
+  {
+    int port;
+    try (ServerSocket server = new ServerSocket(0)) {
+      port = server.getLocalPort();
+    }
+
+    Properties props = new Properties();
+    props.put("broker.id", "0");
+    props.put("host.name", "localhost");
+    props.put("port", port);
+    props.put("log.dir", tempDir.getPath());
+    props.put("zookeeper.connect", zk.getConnectString());
+    props.put("replica.socket.timeout.ms", "1500");
+    return new KafkaConfig(props);
+  }
+
+  @Test(timeout = 15000)
+  public void testStartConsumersNoCommit() throws Exception
+  {
+    final String topic = "testStartConsumersNoCommit";
+    final int numMessages = 5;
+    final CountDownLatch latch = new CountDownLatch(numMessages);
+
+    AdminUtils.createTopic(zkUtils, topic, 1, 1, new Properties());
+    consumerProperties.setProperty("topicPattern", topic);
+
+    TranquilityEventWriter mockEventWriter = EasyMock.mock(TranquilityEventWriter.class);
+    mockEventWriter.send(EasyMock.anyObject());
+    EasyMock.expectLastCall().andStubAnswer(
+        new IAnswer<Void>()
+        {
+          @Override
+          public Void answer() throws Throwable
+          {
+            latch.countDown();
+            return null;
+          }
+        }
+    );
+
+    WriterController mockWriterController = EasyMock.mock(WriterController.class);
+    EasyMock.expect(mockWriterController.getWriter(topic)).andReturn(mockEventWriter).times(numMessages);
+    EasyMock.expect(mockWriterController.flushAll()).andReturn(Maps.<String, MessageCounters>newHashMap());
+
+    mockWriterController.stop();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockWriterController, mockEventWriter);
+
+    TranquilityKafkaConfig config = new ConfigurationObjectFactory(consumerProperties).build(TranquilityKafkaConfig.class);
+
+    FireDepartment fd = new FireDepartment(
+        new DataSchema(topic, null, new AggregatorFactory[]{}, null, new ObjectMapper()),
+        new RealtimeIOConfig(
+            new LocalFirehoseFactory(null, null, null), new PlumberSchool()
+        {
+          @Override
+          public Plumber findPlumber(DataSchema schema, RealtimeTuningConfig config, FireDepartmentMetrics metrics)
+          {
+            return null;
+          }
+        }, null
+        ),
+        null
+    );
+
+    Map<String, DataSourceConfig<TranquilityKafkaConfig>> datasourceConfigs = ImmutableMap.of(
+        topic,
+        new DataSourceConfig<>(
+            config,
+            fd
+        )
+    );
+
+    // commitMillis is set high enough that the commit thread should not run during the test
+    KafkaConsumer kafkaConsumer = new KafkaConsumer(
+        config,
+        consumerProperties,
+        datasourceConfigs,
+        mockWriterController
+    );
+    kafkaConsumer.start();
+
+    producer.send(new ProducerRecord<>("waitForReady", MESSAGE)).get(); // give Kafka time to settle before starting
+    Assert.assertEquals("Unexpected consumer offset", -1, getConsumerOffset(topic));
+
+    for (int i = numMessages; i > 0; i--) {
+      producer.send(new ProducerRecord<>(topic, MESSAGE)).get();
+    }
+    producer.flush();
+    latch.await();
+
+    // check that offset wasn't committed since commit thread didn't run
+    Assert.assertEquals("Unexpected consumer offset", -1, getConsumerOffset(topic));
+
+    kafkaConsumer.stop();
+
+    // check that offset was committed on shutdown
+    Assert.assertEquals("Unexpected consumer offset", numMessages, getConsumerOffset(topic));
+    EasyMock.verify(mockWriterController, mockEventWriter);
+  }
+
+  @Test(timeout = 15000)
+  public void testStartConsumersWithCommitThread() throws Exception
+  {
+    final String topic = "testStartConsumersWithCommitThread";
+    final int numMessages = 8;
+    final CountDownLatch latch = new CountDownLatch(numMessages);
+
+    AdminUtils.createTopic(zkUtils, topic, 1, 1, new Properties());
+    consumerProperties.setProperty("topicPattern", topic);
+
+    TranquilityEventWriter mockEventWriter = EasyMock.mock(TranquilityEventWriter.class);
+    mockEventWriter.send(EasyMock.anyObject());
+    EasyMock.expectLastCall().andStubAnswer(
+        new IAnswer<Void>()
+        {
+          @Override
+          public Void answer() throws Throwable
+          {
+            latch.countDown();
+            return null;
+          }
+        }
+    );
+
+    WriterController mockWriterController = EasyMock.mock(WriterController.class);
+    EasyMock.expect(mockWriterController.getWriter(topic)).andReturn(mockEventWriter).times(numMessages);
+    EasyMock.expect(mockWriterController.flushAll()).andReturn(Maps.<String, MessageCounters>newHashMap()).times(2);
+
+    mockWriterController.stop();
+    EasyMock.expectLastCall();
+
+    EasyMock.replay(mockWriterController, mockEventWriter);
+
+    TranquilityKafkaConfig config = new ConfigurationObjectFactory(consumerProperties).build(TranquilityKafkaConfig.class);
+
+    FireDepartment fd = new FireDepartment(
+        new DataSchema(topic, null, new AggregatorFactory[]{}, null, new ObjectMapper()),
+        new RealtimeIOConfig(
+            new LocalFirehoseFactory(null, null, null), new PlumberSchool()
+        {
+          @Override
+          public Plumber findPlumber(DataSchema schema, RealtimeTuningConfig config, FireDepartmentMetrics metrics)
+          {
+            return null;
+          }
+        }, null
+        ),
+        null
+    );
+
+    Map<String, DataSourceConfig<TranquilityKafkaConfig>> datasourceConfigs = ImmutableMap.of(
+        topic,
+        new DataSourceConfig<>(
+            config,
+            fd
+        )
+    );
+
+    // commitMillis is set high enough that the commit thread should not run during the test
+    KafkaConsumer kafkaConsumer = new KafkaConsumer(
+        config,
+        consumerProperties,
+        datasourceConfigs,
+        mockWriterController
+    );
+    kafkaConsumer.start();
+
+    producer.send(new ProducerRecord<>("waitForReady", MESSAGE)).get(); // give Kafka time to settle before starting
+    Assert.assertEquals("Unexpected consumer offset", -1, getConsumerOffset(topic));
+
+    for (int i = numMessages; i > 0; i--) {
+      producer.send(new ProducerRecord<>(topic, MESSAGE)).get();
+    }
+    producer.flush();
+    latch.await();
+
+    kafkaConsumer.commit();
+
+    // check that offset was committed since commit ran
+    Assert.assertEquals("Unexpected consumer offset", numMessages, getConsumerOffset(topic));
+
+    kafkaConsumer.stop();
+
+    Assert.assertEquals("Unexpected consumer offset", numMessages, getConsumerOffset(topic));
+    EasyMock.verify(mockWriterController, mockEventWriter);
+  }
+
+  private long getConsumerOffset(String topic)
+  {
+    TopicAndPartition partition = new TopicAndPartition(topic, 0);
+    OffsetFetchRequest fetchRequest = new OffsetFetchRequest(
+        GROUP_ID, Lists.newArrayList(partition),
+        (short) 0, // version 1 and above fetch from Kafka, version 0 fetches from ZooKeeper
+        0, CLIENT_ID
+    );
+
+    if (!channel.isConnected()) {
+      channel.connect();
+    }
+
+    channel.send(fetchRequest.underlying());
+
+    OffsetFetchResponse fetchResponse = OffsetFetchResponse.readFrom(channel.receive().payload());
+    OffsetMetadataAndError result = fetchResponse.offsets().get(partition);
+    return result.offset();
+  }
+}

--- a/kafka/src/test/java/com/metamx/tranquility/kafka/writer/WriterControllerTest.java
+++ b/kafka/src/test/java/com/metamx/tranquility/kafka/writer/WriterControllerTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.kafka.writer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import com.metamx.tranquility.config.DataSourceConfig;
+import com.metamx.tranquility.kafka.model.MessageCounters;
+import com.metamx.tranquility.kafka.model.TranquilityKafkaConfig;
+import io.druid.query.aggregation.AggregatorFactory;
+import io.druid.segment.indexing.DataSchema;
+import io.druid.segment.indexing.RealtimeIOConfig;
+import io.druid.segment.indexing.RealtimeTuningConfig;
+import io.druid.segment.realtime.FireDepartment;
+import io.druid.segment.realtime.FireDepartmentMetrics;
+import io.druid.segment.realtime.firehose.LocalFirehoseFactory;
+import io.druid.segment.realtime.plumber.Plumber;
+import io.druid.segment.realtime.plumber.PlumberSchool;
+import junit.framework.Assert;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.config.ConfigurationObjectFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class WriterControllerTest
+{
+  class TestableWriterController extends WriterController
+  {
+
+    private Map<String, TranquilityEventWriter> mockWriters = new HashMap<>();
+
+    public TestableWriterController(Map<String, DataSourceConfig<TranquilityKafkaConfig>> dataSourceConfigs)
+    {
+      super(dataSourceConfigs);
+    }
+
+    protected TranquilityEventWriter createWriter(
+        String topic,
+        DataSourceConfig<TranquilityKafkaConfig> dataSourceConfig
+    )
+    {
+      TranquilityEventWriter writer = EasyMock.mock(TranquilityEventWriter.class);
+      mockWriters.put(topic, writer);
+      return writer;
+    }
+  }
+
+  private TestableWriterController writerController;
+
+  @Before
+  public void setUp()
+  {
+    Properties props = new Properties();
+    props.setProperty("kafka.zookeeper.connect", "localhost:2181");
+    props.setProperty("zookeeper.connect", "localhost:2181");
+
+    Properties propsTwitter = new Properties(props);
+    propsTwitter.setProperty("topicPattern", "twitter");
+
+    Properties propsTest = new Properties(props);
+    propsTest.setProperty("topicPattern", "test[0-9]");
+    propsTest.setProperty("useTopicAsDataSource", "true");
+
+    FireDepartment fd = new FireDepartment(
+        new DataSchema("twitter", null, new AggregatorFactory[]{}, null, new ObjectMapper()),
+        new RealtimeIOConfig(
+            new LocalFirehoseFactory(null, null, null), new PlumberSchool()
+        {
+          @Override
+          public Plumber findPlumber(DataSchema schema, RealtimeTuningConfig config, FireDepartmentMetrics metrics)
+          {
+            return null;
+          }
+        }, null
+        ),
+        null
+    );
+
+    Map<String, DataSourceConfig<TranquilityKafkaConfig>> datasourceConfigs = ImmutableMap.of(
+        "twitter",
+        new DataSourceConfig<>(new ConfigurationObjectFactory(propsTwitter).build(TranquilityKafkaConfig.class), fd),
+        "test[0-9]",
+        new DataSourceConfig<>(new ConfigurationObjectFactory(propsTest).build(TranquilityKafkaConfig.class), fd)
+    );
+
+    writerController = new TestableWriterController(datasourceConfigs);
+  }
+
+  @Test
+  public void testGetWriter()
+  {
+    Assert.assertEquals(0, writerController.mockWriters.size());
+
+    TranquilityEventWriter writerTwitter = writerController.getWriter("twitter");
+
+    Assert.assertEquals(1, writerController.mockWriters.size());
+    Assert.assertSame(writerTwitter, writerController.mockWriters.get("twitter"));
+    Assert.assertSame(writerTwitter, writerController.getWriter("twitter"));
+
+    TranquilityEventWriter writerTest0 = writerController.getWriter("test0");
+    TranquilityEventWriter writerTest1 = writerController.getWriter("test1");
+
+    Assert.assertEquals(3, writerController.mockWriters.size());
+    Assert.assertSame(writerTest0, writerController.getWriter("test0"));
+    Assert.assertSame(writerTest1, writerController.getWriter("test1"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testGetWriterInvalid()
+  {
+    writerController.getWriter("test10");
+  }
+
+  @Test
+  public void testFlushAll() throws InterruptedException
+  {
+    writerController.getWriter("test0");
+    writerController.getWriter("test1");
+    TranquilityEventWriter mock0 = writerController.mockWriters.get("test0");
+    TranquilityEventWriter mock1 = writerController.mockWriters.get("test1");
+
+    mock0.flush();
+    mock1.flush();
+    EasyMock.expect(mock0.getMessageCounters()).andReturn(new MessageCounters(1, 2, 3));
+    EasyMock.expect(mock1.getMessageCounters()).andReturn(new MessageCounters(4, 5, 6));
+    EasyMock.replay(mock0, mock1);
+
+    Map<String, MessageCounters> results = writerController.flushAll();
+
+    EasyMock.verify(mock0, mock1);
+
+    Assert.assertEquals(2, results.size());
+    Assert.assertEquals(1, results.get("test0").getReceivedCount());
+    Assert.assertEquals(2, results.get("test0").getSentCount());
+    Assert.assertEquals(3, results.get("test0").getFailedCount());
+    Assert.assertEquals(4, results.get("test1").getReceivedCount());
+    Assert.assertEquals(5, results.get("test1").getSentCount());
+    Assert.assertEquals(6, results.get("test1").getFailedCount());
+  }
+
+  @Test
+  public void testStop()
+  {
+    writerController.getWriter("test0");
+    writerController.getWriter("test1");
+    TranquilityEventWriter mock0 = writerController.mockWriters.get("test0");
+    TranquilityEventWriter mock1 = writerController.mockWriters.get("test1");
+
+    mock0.stop();
+    mock1.stop();
+    EasyMock.replay(mock0, mock1);
+
+    writerController.stop();
+
+    EasyMock.verify(mock0, mock1);
+  }
+}

--- a/kafka/src/universal/conf/tranquility-kafka.yaml.example
+++ b/kafka/src/universal/conf/tranquility-kafka.yaml.example
@@ -1,0 +1,97 @@
+dataSources:
+  twitter:
+    spec:
+      dataSchema:
+        dataSource: twitter
+        parser:
+          type: string
+          parseSpec:
+            format: json
+            timestampSpec:
+              column: timestamp
+              format: auto
+            dimensionsSpec:
+              dimensions: [text, hashtags, lat, lon, source, retweet, lang, utc_offset, screen_name, verified]
+              spatialDimensions: [ { dimName: geo, dims: [lat, lon]} ]
+
+        metricsSpec:
+          - { type: count, name: tweets }
+          - { type: longSum, name: followers, fieldName: followers }
+          - { type: longSum, name: retweets, fieldName: retweets }
+          - { type: longSum, name: friends, fieldName: friends }
+          - { type: longSum, name: statuses, fieldName: statuses }
+
+        granularitySpec:
+          type: uniform
+          segmentGranularity: hour
+          queryGranularity: none
+
+      ioConfig:
+        type: realtime
+
+      tuningConfig:
+        type: realtime
+        maxRowsInMemory: 100000
+        intermediatePersistPeriod: PT10M
+        windowPeriod: PT10M
+
+    properties:
+      topicPattern: twitter
+      topicPattern.priority: 1
+      useTopicAsDataSource: false
+
+  wikipedia:
+    spec:
+      dataSchema:
+        dataSource: wikipedia
+        parser:
+          type: string
+          parseSpec:
+            format: json
+            timestampSpec:
+              column: timestamp
+              format: auto
+            dimensionsSpec:
+              dimensions: [page, language, user, unpatrolled, newPage, robot, anonymous, namespace, continent, country, region, city]
+
+        metricsSpec:
+          - { type: count, name: count }
+          - { type: doubleSum, name: added, fieldName: added }
+          - { type: doubleSum, name: deleted, fieldName: deleted }
+          - { type: doubleSum, name: delta, fieldName: delta }
+
+        granularitySpec:
+          type: uniform
+          segmentGranularity: hour
+          queryGranularity: none
+
+      ioConfig:
+        type: realtime
+
+      tuningConfig:
+        type: realtime
+        maxRowsInMemory: 100000
+        intermediatePersistPeriod: PT10M
+        windowPeriod: PT10M
+
+    properties:
+      task.partitions: 2
+      task.replicants: 2
+      topicPattern: wikipedia.*
+      topicPattern.priority: 1
+      useTopicAsDataSource: true
+
+properties:
+  zookeeper.connect: localhost:2181
+  zookeeper.timeout: PT20S
+  druid.discovery.curator.path: /druid/discovery
+  druid.selectors.indexing.serviceName: druid/overlord
+  kafka.zookeeper.connect: localhost:2181
+  kafka.group.id: tranquility-kafka
+  consumer.numThreads: 2
+  commit.periodMillis: 15000
+  task.partitions: 1
+  task.replicants: 1
+  reportDropsAsExceptions: false
+  #druid.extensions.coordinates: "[\"io.druid.extensions:druid-histogram:0.8.2\"]"
+  #druid.extensions.localRepository: /path/to/druid/extensions-repo

--- a/server/src/main/scala/com/metamx/tranquility/server/config.scala
+++ b/server/src/main/scala/com/metamx/tranquility/server/config.scala
@@ -19,101 +19,18 @@
 
 package com.metamx.tranquility.server
 
-import com.metamx.common.scala.net.curator.DiscoAnnounceConfig
-import com.metamx.common.scala.net.curator.DiscoConfig
-import com.metamx.tranquility.beam.ClusteredBeamTuning
-import com.metamx.tranquility.druid.DruidBeamConfig
-import com.metamx.tranquility.tranquilizer.Tranquilizer
-import io.druid.segment.realtime.FireDepartment
+import com.metamx.tranquility.config.TranquilityConfig
 import org.joda.time.Period
 import org.skife.config.Config
 
-object config
+abstract class ServerConfig extends TranquilityConfig(Set("http.port", "http.threads", "http.idleTimeout"))
 {
+  @Config(Array("http.port"))
+  def httpPort: Int = 8200
 
-  val GlobalProperties = Set("http.port", "http.threads", "http.idleTimeout")
+  @Config(Array("http.threads"))
+  def httpThreads: Int = 8
 
-  abstract class GlobalConfig
-  {
-    @Config(Array("http.port"))
-    def httpPort: Int = 8200
-
-    @Config(Array("http.threads"))
-    def httpThreads: Int = 8
-
-    @Config(Array("http.idleTimeout"))
-    def httpIdleTimeout: Period = new Period("PT5M")
-  }
-
-  abstract class GeneralConfig extends GlobalConfig with DiscoConfig
-  {
-    @Config(Array("druid.selectors.indexing.serviceName"))
-    def druidIndexingServiceName: String = "druid/overlord"
-
-    @Config(Array("task.partitions"))
-    def taskPartitions: Int = ClusteredBeamTuning().partitions
-
-    @Config(Array("task.replicants"))
-    def taskReplicants: Int = ClusteredBeamTuning().replicants
-
-    @Config(Array("task.warmingPeriod"))
-    def taskWarmingPeriod: Period = ClusteredBeamTuning().warmingPeriod
-
-    @Config(Array("zookeeper.connect"))
-    def zookeeperConnect: String
-
-    @Config(Array("zookeeper.timeout"))
-    def zookeeperTimeout: Period = new Period("PT20S")
-
-    @Config(Array("tranquility.maxBatchSize"))
-    def tranquilityMaxBatchSize: Int = Tranquilizer.DefaultMaxBatchSize
-
-    @Config(Array("tranquility.maxPendingBatches"))
-    def tranquilityMaxPendingBatches: Int = Tranquilizer.DefaultMaxPendingBatches
-
-    @Config(Array("tranquility.lingerMillis"))
-    def tranquilityLingerMillis: Int = Tranquilizer.DefaultLingerMillis
-
-    @Config(Array("druidBeam.firehoseGracePeriod"))
-    def firehoseGracePeriod: Period = DruidBeamConfig().firehoseGracePeriod
-
-    @Config(Array("druidBeam.firehoseQuietPeriod"))
-    def firehoseQuietPeriod: Period = DruidBeamConfig().firehoseQuietPeriod
-
-    @Config(Array("druidBeam.firehoseRetryPeriod"))
-    def firehoseRetryPeriod: Period = DruidBeamConfig().firehoseRetryPeriod
-
-    @Config(Array("druidBeam.firehoseChunkSize"))
-    def firehoseChunkSize: Int = DruidBeamConfig().firehoseChunkSize
-
-    @Config(Array("druidBeam.randomizeTaskId"))
-    def randomizeTaskId: Boolean = DruidBeamConfig().randomizeTaskId
-
-    @Config(Array("druidBeam.indexRetryPeriod"))
-    def indexRetryPeriod: Period = DruidBeamConfig().indexRetryPeriod
-
-    @Config(Array("druidBeam.firehoseBufferSize"))
-    def firehoseBufferSize: Int = DruidBeamConfig().firehoseBufferSize
-
-    @Config(Array("druid.discovery.curator.path"))
-    def discoPath: String = "/druid/discovery"
-
-    override def discoAnnounce: Option[DiscoAnnounceConfig] = None
-
-    def druidBeamConfig: DruidBeamConfig = DruidBeamConfig.builder()
-      .firehoseGracePeriod(firehoseGracePeriod)
-      .firehoseQuietPeriod(firehoseQuietPeriod)
-      .firehoseRetryPeriod(firehoseRetryPeriod)
-      .firehoseChunkSize(firehoseChunkSize)
-      .randomizeTaskId(randomizeTaskId)
-      .indexRetryPeriod(indexRetryPeriod)
-      .firehoseBufferSize(firehoseBufferSize)
-      .build()
-  }
-
-  case class DataSourceConfig(
-    config: GeneralConfig,
-    fireDepartment: FireDepartment
-  )
-
+  @Config(Array("http.idleTimeout"))
+  def httpIdleTimeout: Period = new Period("PT5M")
 }

--- a/server/src/test/scala/com/metamx/tranquility/server/ServerConfigTest.scala
+++ b/server/src/test/scala/com/metamx/tranquility/server/ServerConfigTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.server
+
+import com.metamx.tranquility.config.ConfigHelper
+import org.joda.time.Period
+import org.scalatest.FunSuite
+import org.scalatest.ShouldMatchers
+
+class ServerConfigTest extends FunSuite with ShouldMatchers
+{
+  test("readConfigYaml") {
+    val (globalConfig, dataSourceConfigs, globalProperties) = ConfigHelper.readConfigYaml(
+      getClass.getClassLoader.getResourceAsStream("tranquility-server.yaml"), classOf[ServerConfig]
+    )
+
+    globalConfig.httpPort should be(8080)
+    globalConfig.httpThreads should be(2)
+
+    dataSourceConfigs.keySet should be(Set("foo"))
+
+    val fooConfig = dataSourceConfigs("foo")
+    fooConfig.fireDepartment.getDataSchema.getDataSource should be("foo")
+    fooConfig.fireDepartment.getDataSchema.getAggregators.map(_.getName).toList should be(Seq("count", "x"))
+    fooConfig.fireDepartment.getTuningConfig.getMaxRowsInMemory should be(100000)
+    fooConfig.fireDepartment.getTuningConfig.getIntermediatePersistPeriod should be(new Period("PT45S"))
+    fooConfig.fireDepartment.getTuningConfig.getWindowPeriod should be(new Period("PT30S"))
+    fooConfig.config.zookeeperConnect should be("zk.example.com")
+    fooConfig.config.taskPartitions should be(3)
+    fooConfig.config.druidBeamConfig.firehoseGracePeriod should be(new Period("PT1S"))
+  }
+}


### PR DESCRIPTION
This PR adds a module to Tranquility to help push data from Kafka into the indexing service through Tranquility. Multiple instances of tranquility-kafka can be run at the same time to provide scalability and high availability, and an instance can read from multiple Kafka topics and write to multiple Druid datasources. Tranquility-kafka supports regex pattern based mapping of Kafka topic to a Druid ingestion spec, thus allowing indexing tasks for new datasources to be automatically created when a new Kafka topic is created that matches the regex. If additional Kafka topic -> ingestion spec mappings need to be added, tranquility-kafka supports rolling updates without data loss.

To build, run: `sbt universal:packageZipTarball`

Unpack the tgz in `/kafka/target/universal/tranquility-kafka-x.x.x.tgz` and run `bin/tranquility-kafka -f conf/config.properties` to start. You'll need to modify config.properties and add some ingestion specs to do anything useful.

I'll be adding unit tests and documentation, but wanted to put this out to get some feedback.