### PR TITLE
Spark: Send using a Tranquilizer to avoid RDD materialization.

### DIFF
--- a/spark/src/main/scala/com/metamx/tranquility/spark/BeamFactory.scala
+++ b/spark/src/main/scala/com/metamx/tranquility/spark/BeamFactory.scala
@@ -19,6 +19,7 @@
 package com.metamx.tranquility.spark
 
 import com.metamx.tranquility.beam.Beam
+import com.metamx.tranquility.tranquilizer.Tranquilizer
 
 /**
   * Implement this class to link up Spark with Tranquility.
@@ -33,4 +34,9 @@ trait BeamFactory[EventType] extends Serializable
     */
   def makeBeam: Beam[EventType]
 
+  @transient final lazy val tranquilizer: Tranquilizer[EventType] = {
+    val t = Tranquilizer.create(makeBeam)
+    t.start()
+    t
+  }
 }


### PR DESCRIPTION
This should allow sending larger RDDs.