### PR TITLE
Add Beam.sendBatch (returns a BitSet of successes)

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/beam/NoopBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/beam/NoopBeam.scala
@@ -19,12 +19,13 @@
 package com.metamx.tranquility.beam
 
 import com.twitter.util.Future
+import scala.collection.immutable.BitSet
 
 class NoopBeam[A] extends Beam[A]
 {
-  def propagate(events: Seq[A]) = Future.value(0)
+  override def sendBatch(messages: Seq[A]): Future[BitSet] = Future.value(BitSet.empty)
 
-  def close() = Future.Done
+  override def close() = Future.Done
 
   override def toString = "NoopBeam()"
 }

--- a/core/src/main/scala/com/metamx/tranquility/beam/RoundRobinBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/beam/RoundRobinBeam.scala
@@ -21,21 +21,22 @@ package com.metamx.tranquility.beam
 import com.metamx.common.scala.Logging
 import com.twitter.util.Future
 import java.util.concurrent.atomic.AtomicInteger
+import scala.collection.immutable.BitSet
 
 /**
- * Farms out events to various beams, round-robin.
- */
+  * Farms out events to various beams, round-robin.
+  */
 class RoundRobinBeam[A](
   beams: IndexedSeq[Beam[A]]
 ) extends Beam[A] with Logging
 {
   private[this] val n = new AtomicInteger(-1)
 
-  def propagate(events: Seq[A]) = {
-    beams(n.incrementAndGet() % beams.size).propagate(events)
+  override def sendBatch(events: Seq[A]): Future[BitSet] = {
+    beams(n.incrementAndGet() % beams.size).sendBatch(events)
   }
 
-  def close() = {
+  override def close() = {
     Future.collect(beams map (_.close())) map (_ => ())
   }
 

--- a/core/src/main/scala/com/metamx/tranquility/beam/TransformingBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/beam/TransformingBeam.scala
@@ -20,11 +20,12 @@
 package com.metamx.tranquility.beam
 
 import com.twitter.util.Future
+import scala.collection.immutable.BitSet
 
 class TransformingBeam[A, B](underlying: Beam[B], f: A => B) extends Beam[A]
 {
-  override def propagate(events: Seq[A]): Future[Int] = {
-    underlying.propagate(events.map(f))
+  override def sendBatch(events: Seq[A]): Future[BitSet] = {
+    underlying.sendBatch(events.map(f))
   }
 
   override def close(): Future[Unit] = {

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -479,9 +479,9 @@ object DruidBeams
       )
       new Beam[EventType]
       {
-        def propagate(events: Seq[EventType]) = clusteredBeam.propagate(events)
+        override def sendBatch(events: Seq[EventType]) = clusteredBeam.sendBatch(events)
 
-        def close() = clusteredBeam.close() map (_ => indexService.close())
+        override def close() = clusteredBeam.close() map (_ => indexService.close())
 
         override def toString = clusteredBeam.toString
       }

--- a/core/src/main/scala/com/metamx/tranquility/finagle/BeamService.scala
+++ b/core/src/main/scala/com/metamx/tranquility/finagle/BeamService.scala
@@ -20,6 +20,7 @@ package com.metamx.tranquility.finagle
 
 import com.metamx.tranquility.beam.Beam
 import com.twitter.finagle.Service
+import com.twitter.util.Future
 import com.twitter.util.Time
 
 /**
@@ -27,7 +28,7 @@ import com.twitter.util.Time
  */
 class BeamService[A](beam: Beam[A]) extends Service[Seq[A], Int]
 {
-  def apply(request: Seq[A]) = beam.propagate(request)
+  def apply(request: Seq[A]): Future[Int] = beam.sendBatch(request).map(_.size)
 
   override def close(deadline: Time) = beam.close()
 }

--- a/core/src/test/scala/com/metamx/tranquility/test/BeamPacketizerTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/BeamPacketizerTest.scala
@@ -20,9 +20,9 @@
 package com.metamx.tranquility.test
 
 import com.fasterxml.jackson.core.JsonGenerator
-import com.metamx.common.scala.untyped.Dict
 import com.metamx.common.scala.Jackson
 import com.metamx.common.scala.Logging
+import com.metamx.common.scala.untyped.Dict
 import com.metamx.tranquility.beam.Beam
 import com.metamx.tranquility.beam.BeamPacketizer
 import com.metamx.tranquility.beam.BeamPacketizerListener
@@ -31,6 +31,7 @@ import com.metamx.tranquility.typeclass.JsonWriter
 import com.twitter.util.Future
 import java.util.concurrent.atomic.AtomicLong
 import org.scalatest.FunSuite
+import scala.collection.immutable.BitSet
 
 class BeamPacketizerTest extends FunSuite with Logging
 {
@@ -49,11 +50,11 @@ class BeamPacketizerTest extends FunSuite with Logging
       }
     )
     val beam = new Beam[String] {
-      override def propagate(events: Seq[String]) = {
+      override def sendBatch(events: Seq[String]): Future[BitSet] = {
         if (events.contains("__fail__")) {
           Future.exception(new IllegalStateException("fail!"))
         } else {
-          memoryBeam.propagate(events)
+          memoryBeam.sendBatch(events)
         }
       }
 

--- a/server/src/test/scala/com/metamx/tranquility/server/ServerDruidTest.scala
+++ b/server/src/test/scala/com/metamx/tranquility/server/ServerDruidTest.scala
@@ -74,7 +74,7 @@ class ServerDruidTest
             Jackson.parse[Dict](tester.bodyBytes) should be(
               Dict(
                 "result" -> Dict(
-                  "received" -> 2,
+                  "received" -> 3,
                   "sent" -> 2
                 )
               )

--- a/server/src/test/scala/com/metamx/tranquility/server/TranquilityServletTest.scala
+++ b/server/src/test/scala/com/metamx/tranquility/server/TranquilityServletTest.scala
@@ -26,13 +26,14 @@ import com.metamx.common.scala.collection.implicits._
 import com.metamx.common.scala.untyped._
 import com.metamx.tranquility.beam.Beam
 import com.metamx.tranquility.beam.MemoryBeam
-import com.metamx.tranquility.server.TranquilityServletTest._
 import com.metamx.tranquility.server.ServerTestUtil.withTester
+import com.metamx.tranquility.server.TranquilityServletTest._
 import com.metamx.tranquility.typeclass.JsonWriter
 import com.twitter.util.Await
 import com.twitter.util.Future
 import org.scalatest.FunSuite
 import org.scalatest.ShouldMatchers
+import scala.collection.immutable.BitSet
 
 class TranquilityServletTest extends FunSuite with ShouldMatchers
 {
@@ -237,11 +238,11 @@ object TranquilityServletTest
 
     val beams: Map[String, Beam[Dict]] = memoryBeams strictMapValues { memoryBeam =>
       new Beam[Dict] {
-        override def propagate(events: Seq[Dict]) = {
+        override def sendBatch(events: Seq[Dict]): Future[BitSet] = {
           if (events.exists(_.get(ActionKey) == Some("__fail__"))) {
             Future.exception(new IllegalStateException("fail!"))
           } else {
-            memoryBeam.propagate(events.filterNot(_.get(ActionKey) == Some("__drop__")))
+            memoryBeam.sendBatch(events.filterNot(_.get(ActionKey) == Some("__drop__")))
           }
         }
 

--- a/storm/src/main/scala/com/metamx/tranquility/storm/TridentBeamState.scala
+++ b/storm/src/main/scala/com/metamx/tranquility/storm/TridentBeamState.scala
@@ -38,7 +38,7 @@ class TridentBeamState[EventType](beam: Beam[EventType])
 
   def send(events: Seq[EventType]): Int = {
     log.debug("Sending %,d events with txid[%s]", events.size, txid.getOrElse("none"))
-    Await.result(beam.propagate(events))
+    Await.result(beam.sendBatch(events)).size
   }
 
   def close() {

--- a/storm/src/test/scala/com/metamx/tranquility/test/StormBoltTest.scala
+++ b/storm/src/test/scala/com/metamx/tranquility/test/StormBoltTest.scala
@@ -22,9 +22,7 @@ package com.metamx.tranquility.test
 import backtype.storm.Config
 import backtype.storm.task.IMetricsContext
 import backtype.storm.topology.TopologyBuilder
-import com.google.common.collect.Lists
 import com.metamx.common.scala.Logging
-import com.metamx.common.scala.Predef._
 import com.metamx.tranquility.beam.Beam
 import com.metamx.tranquility.storm.BeamBolt
 import com.metamx.tranquility.storm.BeamFactory
@@ -34,26 +32,21 @@ import com.metamx.tranquility.storm.common.StormRequiringSuite
 import com.metamx.tranquility.test.common.CuratorRequiringSuite
 import com.metamx.tranquility.test.common.JulUtils
 import com.twitter.util.Future
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.ObjectInputStream
-import java.io.ObjectOutputStream
-import java.net.URLClassLoader
 import java.{util => ju}
 import org.scala_tools.time.Imports._
 import org.scalatest.FunSuite
+import scala.collection.immutable.BitSet
 import scala.collection.mutable
-import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 class SimpleBeam extends Beam[SimpleEvent]
 {
-  def propagate(events: Seq[SimpleEvent]) = {
+  override def sendBatch(events: Seq[SimpleEvent]): Future[BitSet] = {
     SimpleBeam.buffer ++= events
-    Future.value(events.size)
+    Future.value(BitSet.empty ++ events.indices)
   }
 
-  def close() = Future.Done
+  override def close() = Future.Done
 }
 
 object SimpleBeam


### PR DESCRIPTION
Add Beam.sendBatch (returns a BitSet of successes), fixes #56.

Also:

- Deprecate Beam.propagate
- Make Tranquilizer's MessageDroppedException a singleton
- Improve ClusteredBeam tests and add tests involving dropping events