### PR TITLE
Server: Switch to real arg parsing, and rename Main to ServerMain.

### DIFF
--- a/server/src/test/scala/com/metamx/tranquility/server/ServerMainTest.scala
+++ b/server/src/test/scala/com/metamx/tranquility/server/ServerMainTest.scala
@@ -19,15 +19,15 @@
 
 package com.metamx.tranquility.server
 
-import com.metamx.tranquility.server.http.Main
+import com.metamx.tranquility.server.http.ServerMain
 import org.joda.time.Period
 import org.scalatest.FunSuite
 import org.scalatest.ShouldMatchers
 
-class MainTest extends FunSuite with ShouldMatchers
+class ServerMainTest extends FunSuite with ShouldMatchers
 {
   test("readConfigYaml") {
-    val (globalConfig, dataSourceConfigs) = Main.readConfigYaml(
+    val (globalConfig, dataSourceConfigs) = ServerMain.readConfigYaml(
       getClass.getClassLoader.getResourceAsStream("tranquility-server.yaml")
     )
 


### PR DESCRIPTION
Real arg parsing is probably a better idea than reading `args(0)`.