### PR TITLE
Apache Flink module

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Modules:
 - [Spark](docs/spark.md) - Tranquility works with RDDs and DStreams.
 - [Storm](docs/storm.md) - Tranquility includes a Storm Bolt and a Trident State.
 - [Kafka](docs/kafka.md) - Application to push messages from Kafka into Druid through Tranquility.
+- [Flink](docs/flink.md) - Tranquility includes a Flink Sink.
 
 ### Getting Tranquility with Maven
 

--- a/docs/flink.md
+++ b/docs/flink.md
@@ -1,0 +1,53 @@
+# Flink
+
+If you're using Flink to process your event stream, you can use Tranquility's BeamSink to send data to
+Druid. The BeamSink can be added to any DataStream object. The BeamSink requires a BeamFactory to 
+propagate events. You will be overriding the makeBeam() function and within that
+using the DruidBeams builder's "buildBeam()" to build the beam. See the [DruidBeams documentation](druidbeams.md)
+for details about creating beams.
+
+It is recommended that you implement makeBeam as a lazy val so the Beam can be reused.
+
+For example:
+
+```scala
+
+class SimpleEventBeamFactory extends BeamFactory[SimpleEvent]
+{
+
+  lazy val makeBeam: Beam[SimpleEvent] = {
+
+    // Tranquility uses ZooKeeper (through Curator framework) for coordination.
+    val curator = CuratorFrameworkFactory.newClient(
+      "localhost:2181",
+      new BoundedExponentialBackoffRetry(100, 3000, 5)
+    )
+    curator.start()
+
+    val indexService = "druid/overlord" // Your overlord's druid.service, with slashes replaced by colons.
+    val discoveryPath = "/druid/discovery" // Your overlord's druid.discovery.curator.path
+    val dataSource = "foo"
+    val dimensions = IndexedSeq("bar")
+    val aggregators = Seq(new LongSumAggregatorFactory("baz", "baz"))
+
+    DruidBeams
+      .builder((eventMap: SimpleEvent) => new DateTime())
+      .curator(curator)
+      .discoveryPath(discoveryPath)
+      .location(DruidLocation.create(indexService, dataSource))
+      .rollup(DruidRollup(SpecificDruidDimensions(dimensions), aggregators, QueryGranularity.MINUTE))
+      .tuning(
+        ClusteredBeamTuning(
+          segmentGranularity = Granularity.HOUR,
+          windowPeriod = new Period("PT10M"),
+          partitions = 1,
+          replicants = 1
+        )
+      )
+      .buildBeam()
+  }
+}
+
+// now you can create a sink and add it to a given DataStream object.
+dstream.addSink(new BeamSink[SimpleEvent](new SimpleEventBeamFactory(zkConnect)))
+```

--- a/flink/src/main/scala/com/metamx/tranquility/flink/BeamFactory.scala
+++ b/flink/src/main/scala/com/metamx/tranquility/flink/BeamFactory.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.metamx.tranquility.flink
+
+import com.metamx.tranquility.beam.Beam
+import com.metamx.tranquility.tranquilizer.Tranquilizer
+
+/**
+  * Implement this class to link up Flink with Tranquility.
+  */
+trait BeamFactory[EventType] extends Serializable
+{
+  /**
+    * Create a Beam for a given EventType.
+    * It is recommended that this class should override the makeBeam method as a lazy val.
+    *
+    * @return beam for an EventType
+    */
+  def makeBeam: Beam[EventType]
+
+  @transient final lazy val tranquilizer: Tranquilizer[EventType] = {
+    val t = Tranquilizer.create(makeBeam)
+    t.start()
+    t
+  }
+
+}

--- a/flink/src/main/scala/com/metamx/tranquility/flink/BeamSink.scala
+++ b/flink/src/main/scala/com/metamx/tranquility/flink/BeamSink.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.metamx.tranquility.flink
+
+import com.metamx.common.scala.Logging
+import com.metamx.tranquility.tranquilizer.SimpleTranquilizerAdapter
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
+
+/**
+  * This class provides a sink that can propagate any event type to Druid.
+  * @param beamFactory your implementation of [[BeamFactory]].
+  */
+class BeamSink[T](beamFactory: BeamFactory[T])
+  extends RichSinkFunction[T] with Logging
+{
+  var sender: Option[SimpleTranquilizerAdapter[T]] = None
+
+  override def open(parameters: Configuration) = {
+    sender = Some(beamFactory.tranquilizer.simple(false))
+  }
+
+  override def invoke(value: T) = sender.get.send(value)
+
+  override def close() = sender.get.flush()
+}

--- a/flink/src/test/scala/com/metamx/tranquility/test/FlinkDruidTest.scala
+++ b/flink/src/test/scala/com/metamx/tranquility/test/FlinkDruidTest.scala
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.test
+
+import com.metamx.common.scala.Logging
+import com.metamx.common.scala.Predef._
+import com.metamx.common.scala.timekeeper.TestingTimekeeper
+import com.metamx.tranquility.beam.Beam
+import com.metamx.tranquility.flink.BeamFactory
+import com.metamx.tranquility.flink.BeamSink
+import com.metamx.tranquility.test.common.CuratorRequiringSuite
+import com.metamx.tranquility.test.common.DruidIntegrationSuite
+import com.metamx.tranquility.test.common.JulUtils
+import java.util.concurrent.TimeUnit
+import org.apache.curator.framework.CuratorFrameworkFactory
+import org.apache.curator.retry.BoundedExponentialBackoffRetry
+import org.apache.flink.api.scala._
+import org.apache.flink.runtime.StreamingMode
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.test.util.ForkableFlinkMiniCluster
+import org.apache.flink.test.util.TestBaseUtils
+import org.junit.runner.RunWith
+import org.scala_tools.time.Imports._
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FunSuite
+import scala.concurrent.duration.FiniteDuration
+
+@RunWith(classOf[JUnitRunner])
+class FlinkDruidTest extends FunSuite with DruidIntegrationSuite with CuratorRequiringSuite
+with Logging with BeforeAndAfter
+{
+  var cluster: Option[ForkableFlinkMiniCluster] = None
+  val parallelism                               = 4
+
+  before {
+    val cl = TestBaseUtils.startCluster(
+      1,
+      parallelism,
+      StreamingMode.STREAMING,
+      false,
+      false,
+      true
+    )
+
+    cluster = Some(cl)
+  }
+
+  after {
+    val timeout: FiniteDuration = new FiniteDuration(1000, TimeUnit.SECONDS)
+    cluster.foreach(c => TestBaseUtils.stopCluster(c, timeout))
+  }
+
+  JulUtils.routeJulThroughSlf4j()
+  test("Flink to Druid") {
+    withDruidStack {
+      (curator, broker, coordinator, overlord) =>
+        val zkConnect = curator.getZookeeperClient.getCurrentConnectionString
+        val now = new DateTime().hourOfDay().roundFloorCopy()
+        val env = StreamExecutionEnvironment.getExecutionEnvironment
+        val inputs = DirectDruidTest.generateEvents(now)
+        val sink = new BeamSink[SimpleEvent](new SimpleEventBeamFactory(zkConnect))
+
+        env.fromCollection(inputs).addSink(sink)
+        env.execute
+
+        runTestQueriesAndAssertions(
+          broker, new TestingTimekeeper withEffect {
+            timekeeper =>
+              timekeeper.now = now
+          }
+        )
+    }
+  }
+}
+
+class SimpleEventBeamFactory(zkConnect: String) extends BeamFactory[SimpleEvent]
+{
+  override lazy val makeBeam: Beam[SimpleEvent] = {
+    val aDifferentCurator = CuratorFrameworkFactory.newClient(
+      zkConnect,
+      new BoundedExponentialBackoffRetry(100, 1000, 5)
+    )
+    aDifferentCurator.start()
+    val builder = DirectDruidTest.newBuilder(
+      aDifferentCurator, new TestingTimekeeper withEffect {
+        timekeeper =>
+          timekeeper.now = DateTime.now
+      }
+    )
+    builder.buildBeam()
+  }
+}
+
+


### PR DESCRIPTION
This module adds support for Apache Flink. Works and looks a lot like the Spark module. But instead of the `BeamRDD` it contains `BeamSink`.

Had some struggle with the Flink dependency imports since they are not following the Scala naming conventions.

Would be great to get some feedback on this and even greater to get it merge.