### PR TITLE
Changes to make configuration files easier to use.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -95,7 +95,7 @@ object DruidBeams
     * @param fireDepartment druid realtime spec
     * @return a new builder
     */
-  @deprecated("0.7.3", "use builderFromSpecJava or builderFromSpecScala")
+  @deprecated("use builderFromSpecJava or builderFromSpecScala", "0.7.3")
   def builder(
     environment: DruidEnvironment,
     fireDepartment: FireDepartment
@@ -166,13 +166,13 @@ object DruidBeams
     *
     * @param messageToJavaMap function that translates messages to Java maps
     * @param environment druid environment
-    * @param specMap druid realtime spec map
+    * @param specMap0 druid realtime spec map
     * @return a new builder
     */
   private def builderFromSpec[MessageType](
     messageToJavaMap: MessageType => java.util.Map[String, AnyRef],
     environment: DruidEnvironment,
-    specMap: Dict
+    specMap0: Dict
   ): Builder[MessageType] =
   {
     def j2s[A](xs: ju.List[A]): IndexedSeq[A] = xs match {
@@ -183,8 +183,11 @@ object DruidBeams
       case null => Set.empty
       case _ => xs.asScala.toSet
     }
+    // Don't require people to specify a needless ioConfig
+    val specMap = Map("ioConfig" -> Dict("type" -> "realtime")) ++ specMap0
     val fireDepartment = DruidGuicer.objectMapper.convertValue(normalizeJava(specMap), classOf[FireDepartment])
     require(fireDepartment.getIOConfig.getFirehoseFactory == null, "Expected null 'firehose'")
+    require(fireDepartment.getIOConfig.getFirehoseFactoryV2 == null, "Expected null 'firehoseV2'")
     require(fireDepartment.getIOConfig.getPlumberSchool == null, "Expected null 'plumber'")
     val parseSpec = fireDepartment.getDataSchema.getParser.getParseSpec
     val timestampSpec = parseSpec.getTimestampSpec

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidTuning.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidTuning.scala
@@ -39,7 +39,7 @@ object DruidTuning
     * @param intermediatePersistPeriod period that determines the rate at which intermediate persists occur
     * @param maxPendingPersists number of persists that can be pending, but not started
     */
-  @deprecated("0.7.3", "use 'apply' or 'builder'")
+  @deprecated("use 'apply' or 'builder'", "0.7.3")
   def create(
     maxRowsInMemory: Int,
     intermediatePersistPeriod: Period,

--- a/core/src/test/resources/tranquility-core-no-tuningConfig.json
+++ b/core/src/test/resources/tranquility-core-no-tuningConfig.json
@@ -40,13 +40,6 @@
             "segmentGranularity" : "hour"
           },
           "dataSource" : "foo"
-        },
-        "tuningConfig" : {
-          "type" : "realtime",
-          "intermediatePersistPeriod" : "PT45S",
-          "maxRowsInMemory" : "100000",
-          "buildV9Directly" : "true",
-          "windowPeriod" : "PT30S"
         }
       }
     }

--- a/distribution/src/universal/conf/kafka.json.example
+++ b/distribution/src/universal/conf/kafka.json.example
@@ -1,0 +1,174 @@
+{
+   "properties" : {
+      "zookeeper.timeout" : "PT20S",
+      "task.partitions" : "1",
+      "commit.periodMillis" : "15000",
+      "druid.selectors.indexing.serviceName" : "druid/overlord",
+      "kafka.group.id" : "tranquility-kafka",
+      "consumer.numThreads" : "2",
+      "task.replicants" : "1",
+      "reportDropsAsExceptions" : "false",
+      "kafka.zookeeper.connect" : "localhost:2181",
+      "zookeeper.connect" : "localhost:2181",
+      "druid.discovery.curator.path" : "/druid/discovery"
+   },
+   "dataSources" : {
+      "twitter" : {
+         "spec" : {
+            "dataSchema" : {
+               "parser" : {
+                  "type" : "string",
+                  "parseSpec" : {
+                     "timestampSpec" : {
+                        "format" : "auto",
+                        "column" : "timestamp"
+                     },
+                     "dimensionsSpec" : {
+                        "spatialDimensions" : [
+                           {
+                              "dims" : [
+                                 "lat",
+                                 "lon"
+                              ],
+                              "dimName" : "geo"
+                           }
+                        ],
+                        "dimensions" : [
+                           "text",
+                           "hashtags",
+                           "lat",
+                           "lon",
+                           "source",
+                           "retweet",
+                           "lang",
+                           "utc_offset",
+                           "screen_name",
+                           "verified"
+                        ]
+                     },
+                     "format" : "json"
+                  }
+               },
+               "dataSource" : "twitter",
+               "granularitySpec" : {
+                  "segmentGranularity" : "hour",
+                  "type" : "uniform",
+                  "queryGranularity" : "none"
+               },
+               "metricsSpec" : [
+                  {
+                     "type" : "count",
+                     "name" : "tweets"
+                  },
+                  {
+                     "fieldName" : "followers",
+                     "type" : "longSum",
+                     "name" : "followers"
+                  },
+                  {
+                     "name" : "retweets",
+                     "type" : "longSum",
+                     "fieldName" : "retweets"
+                  },
+                  {
+                     "fieldName" : "friends",
+                     "type" : "longSum",
+                     "name" : "friends"
+                  },
+                  {
+                     "name" : "statuses",
+                     "type" : "longSum",
+                     "fieldName" : "statuses"
+                  }
+               ]
+            },
+            "tuningConfig" : {
+               "maxRowsInMemory" : "100000",
+               "type" : "realtime",
+               "windowPeriod" : "PT10M",
+               "intermediatePersistPeriod" : "PT10M"
+            }
+         },
+         "properties" : {
+            "topicPattern.priority" : "1",
+            "topicPattern" : "twitter",
+            "useTopicAsDataSource" : "false"
+         }
+      },
+      "wikipedia" : {
+         "spec" : {
+            "ioConfig" : {
+               "type" : "realtime"
+            },
+            "dataSchema" : {
+               "granularitySpec" : {
+                  "queryGranularity" : "none",
+                  "type" : "uniform",
+                  "segmentGranularity" : "hour"
+               },
+               "dataSource" : "wikipedia",
+               "parser" : {
+                  "type" : "string",
+                  "parseSpec" : {
+                     "timestampSpec" : {
+                        "format" : "auto",
+                        "column" : "timestamp"
+                     },
+                     "format" : "json",
+                     "dimensionsSpec" : {
+                        "dimensions" : [
+                           "page",
+                           "language",
+                           "user",
+                           "unpatrolled",
+                           "newPage",
+                           "robot",
+                           "anonymous",
+                           "namespace",
+                           "continent",
+                           "country",
+                           "region",
+                           "city"
+                        ]
+                     }
+                  }
+               },
+               "metricsSpec" : [
+                  {
+                     "type" : "count",
+                     "name" : "count"
+                  },
+                  {
+                     "type" : "doubleSum",
+                     "name" : "added",
+                     "fieldName" : "added"
+                  },
+                  {
+                     "name" : "deleted",
+                     "type" : "doubleSum",
+                     "fieldName" : "deleted"
+                  },
+                  {
+                     "name" : "delta",
+                     "type" : "doubleSum",
+                     "fieldName" : "delta"
+                  }
+               ]
+            },
+            "tuningConfig" : {
+               "intermediatePersistPeriod" : "PT10M",
+               "windowPeriod" : "PT10M",
+               "type" : "realtime",
+               "maxRowsInMemory" : "100000"
+            }
+         },
+         "properties" : {
+            "useTopicAsDataSource" : "true",
+            "topicPattern" : "wikipedia.*",
+            "task.partitions" : "2",
+            "topicPattern.priority" : "1",
+            "task.replicants" : "2"
+         }
+      }
+   }
+}

--- a/distribution/src/universal/conf/kafka.yaml.example
+++ b/distribution/src/universal/conf/kafka.yaml.example
@@ -26,9 +26,6 @@ dataSources:
           segmentGranularity: hour
           queryGranularity: none
 
-      ioConfig:
-        type: realtime
-
       tuningConfig:
         type: realtime
         maxRowsInMemory: 100000

--- a/distribution/src/universal/conf/server.json.example
+++ b/distribution/src/universal/conf/server.json.example
@@ -1,0 +1,59 @@
+{
+   "dataSources" : {
+      "foo" : {
+         "spec" : {
+            "dataSchema" : {
+               "dataSource" : "foo",
+               "metricsSpec" : [
+                  {
+                     "type" : "count",
+                     "name" : "count"
+                  },
+                  {
+                     "fieldName" : "x",
+                     "type" : "doubleSum",
+                     "name" : "x"
+                  }
+               ],
+               "granularitySpec" : {
+                  "segmentGranularity" : "hour",
+                  "queryGranularity" : "none",
+                  "type" : "uniform"
+               },
+               "parser" : {
+                  "type" : "string",
+                  "parseSpec" : {
+                     "format" : "json",
+                     "timestampSpec" : {
+                        "column" : "timestamp",
+                        "format" : "auto"
+                     },
+                     "dimensionsSpec" : {
+                        "dimensions" : [
+                           "dim1",
+                           "dim2",
+                           "dim3"
+                        ]
+                     }
+                  }
+               }
+            },
+            "tuningConfig" : {
+               "windowPeriod" : "PT10M",
+               "type" : "realtime",
+               "intermediatePersistPeriod" : "PT10M",
+               "maxRowsInMemory" : "100000"
+            }
+         },
+         "properties" : {
+            "task.partitions" : "1",
+            "task.replicants" : "1"
+         }
+      }
+   },
+   "properties" : {
+      "http.port" : "8200",
+      "zookeeper.connect" : "localhost",
+      "http.threads" : "8"
+   }
+}

--- a/distribution/src/universal/conf/server.yaml.example
+++ b/distribution/src/universal/conf/server.yaml.example
@@ -22,9 +22,6 @@ dataSources:
           segmentGranularity: hour
           queryGranularity: none
 
-      ioConfig:
-        type: realtime
-
       tuningConfig:
         type: realtime
         maxRowsInMemory: 100000

--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -12,9 +12,11 @@ Tranquility Kafka is included in the [downloadable distribution](../README.md#do
 
 ### Configuration
 
-Tranquility Kafka uses a YAML file for configuration. You can see an example in `conf/tranquility-kafka.yaml.example` of the
-tarball distribution. You can start off your installation by copying this example file to `conf/tranquility-kafka.yaml`. The
-YAML file has two sections:
+Tranquility Kafka uses a JSON or YAML file for configuration. You can see examples in `conf/kafka.json.sample` and
+`conf/kafka.yaml.example` of the tarball distribution. You can start off your installation by copying either example
+file to `conf/kafka.json` or `conf/kafka.yaml`.
+
+The file has two sections:
 
 1. `dataSources` - per dataSource configuration.
 2. `properties` - general properties that apply to all dataSources. See "Configuration reference" for details.
@@ -22,17 +24,16 @@ YAML file has two sections:
 The dataSources key should contain a mapping of dataSource name to configuration. Each dataSource configuration
 has two sections:
 
-1. `spec` - a YAML representation of a [Druid ingestion spec](http://druid.io/docs/latest/ingestion/index.html). Note
-that the `ioConfig` is expected to be of type `realtime` but otherwise empty (null firehose, null plumber). This is
-because Tranquility supplies its own firehose and plumber.
+1. `spec` - a [Druid ingestion spec](http://druid.io/docs/latest/ingestion/index.html) with no `ioConfig`. Tranquility
+supplies its own firehose and plumber.
 2. `properties` - per dataSource properties. See "Configuration reference" for details.
 
 ### Running
 
-If you've saved your configuration into `conf/tranquility-kafka.yaml`, run the application with:
+If you've saved your configuration into `conf/tranquility-kafka.json`, run the application with:
 
 ```bash
-bin/tranquility kafka -configFile conf/tranquility-kafka.yaml
+bin/tranquility kafka -configFile conf/tranquility-kafka.json
 ```
 
 ## Configuration reference
@@ -61,7 +62,7 @@ customization for certain dataSources.
 |`druid.selectors.indexing.serviceName`|The druid.service name of the indexing service Overlord node.|druid/overlord|
 |`topicPattern`|A regular expression used to match Kafka topics to dataSource configurations. See "Matching Topics to Data Sources" for details.|{match nothing}, must be provided|
 |`topicPattern.priority`|If multiple topicPatterns match the same topic name, the highest priority dataSource configuration will be used. A higher number indicates a higher priority. See "Matching Topics to Data Sources" for details.|1|
-|`useTopicAsDataSource`|Use the Kafka topic as the dataSource name instead of the one provided in the YAML. Useful when combined with a topicPattern that matches more than one Kafka topic. See "Matching Topics to Data Sources" for details.|false|
+|`useTopicAsDataSource`|Use the Kafka topic as the dataSource name instead of the one provided in the configuration file. Useful when combined with a topicPattern that matches more than one Kafka topic. See "Matching Topics to Data Sources" for details.|false|
 |`reportDropsAsExceptions`|Whether or not dropped messages will cause an exception and terminate the application.|false|
 |`task.partitions`|Number of Druid partitions to create.|1|
 |`task.replicants`|Number of instances of each Druid partition to create. This is the *total* number of instances, so 2 replicants means 2 tasks will be created.|1|
@@ -116,7 +117,7 @@ dataSources:
 Given the list of Kafka topics *[wikipedia, wikipedia-fr, wikipedia-es]*:
 
   - The topic *wikipedia* will be matched to the `wikipedia` configuration, even though it also matches `wikipedia-lang`
-  (order in the YAML does not matter) since `wikipedia` has a higher `topicPattern.priority` than `wikipedia-lang`
+  (order in the configuration file does not matter) since `wikipedia` has a higher `topicPattern.priority` than `wikipedia-lang`
   (which has the default priority of 1). This will be mapped to a dataSource named **wikipedia**.
   - The topics *wikipedia-fr* and *wikipedia-es* will both be matched to `wikipedia-lang`. Since `useTopicAsDataSource`
   is set to true, they will be mapped to dataSources named **wikipedia-fr** and **wikipedia-es** respectively and will

--- a/docs/server.md
+++ b/docs/server.md
@@ -41,27 +41,28 @@ Tranquility Server is included in the [downloadable distribution](../README.md#d
 
 ### Configuration
 
-Tranquility Server uses a YAML file for configuration. You can see an example in `conf/server.yaml.example` of the
-tarball distribution. You can start off your installation by copying this example file to `conf/server.yaml`. The
-YAML file has two sections:
+Tranquility Server uses a JSON or YAML file for configuration. You can see examples in `conf/server.json.sample` and
+`conf/server.yaml.example` of the tarball distribution. You can start off your installation by copying either example
+file to `conf/server.json` or `conf/server.yaml`.
+
+The file has two sections:
 
 1. `dataSources` - per dataSource configuration.
-2. `properties` - general server properties that apply to all dataSources. See "Configuration reference" for details.
+2. `properties` - general properties that apply to all dataSources. See "Configuration reference" for details.
 
 The dataSources key should contain a mapping of dataSource name to configuration. Each dataSource configuration
 has two sections:
 
-1. `spec` - a YAML representation of a [Druid ingestion spec](http://druid.io/docs/latest/ingestion/index.html). Note
-that the `ioConfig` is expected to be of type `realtime` but otherwise empty (null firehose, null plumber). This is
-because Tranquility supplies its own firehose and plumber.
+1. `spec` - a [Druid ingestion spec](http://druid.io/docs/latest/ingestion/index.html) with no `ioConfig`. Tranquility
+supplies its own firehose and plumber.
 2. `properties` - per dataSource properties. See "Configuration reference" for details.
 
 ### Running
 
-If you've saved your configuration into `conf/server.yaml`, run the server with:
+If you've saved your configuration into `conf/server.json`, run the server with:
 
 ```bash
-bin/tranquility server -configFile conf/server.yaml
+bin/tranquility server -configFile conf/server.json
 ```
 
 ## Configuration reference


### PR DESCRIPTION
- No longer require "ioConfig", and remove it from the examples.
- Point out in the docs that either JSON or YAML is ok. Add sample configs and tests for JSON.
- Add tests for tuningConfig defaults.