### PR TITLE
Tranquilizer.flush() to make batch / micro-batch oriented workflows easier

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/tranquilizer/SimpleTranquilizerAdapter.scala
+++ b/core/src/main/scala/com/metamx/tranquility/tranquilizer/SimpleTranquilizerAdapter.scala
@@ -102,6 +102,8 @@ class SimpleTranquilizerAdapter[MessageType] private(
     * pending messages are flushed.
     */
   def flush() {
+    tranquilizer.flush()
+
     // Wait for data to flush out.
     pending.synchronized {
       while (pending.get() > 0) {

--- a/core/src/test/scala/com/metamx/tranquility/test/TranquilizerTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/TranquilizerTest.scala
@@ -20,6 +20,7 @@
 package com.metamx.tranquility.test
 
 import com.fasterxml.jackson.core.JsonGenerator
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.metamx.common.scala.Jackson
 import com.metamx.common.scala.Logging
 import com.metamx.common.scala.Predef._
@@ -34,8 +35,11 @@ import com.metamx.tranquility.typeclass.JsonWriter
 import com.twitter.util.Await
 import com.twitter.util.Future
 import com.twitter.util.Promise
+import com.twitter.util.Return
+import com.twitter.util.Throw
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import org.scalatest.FunSuite
 import scala.collection.immutable.BitSet
 import scala.collection.immutable.IndexedSeq
@@ -43,7 +47,12 @@ import scala.util.Random
 
 class TranquilizerTest extends FunSuite with Logging
 {
-  def doSend(tranquilizer: Tranquilizer[String], strings: Seq[String]): (Long, Long, Long) = {
+  def doSend(
+    tranquilizer: Tranquilizer[String],
+    strings: Seq[String],
+    doFlush: Boolean = false
+  ): (Long, Long, Long) =
+  {
     val futures = for (string <- strings) yield {
       tranquilizer.send(string) map { ok =>
         (1L, 0L, 0L)
@@ -53,6 +62,9 @@ class TranquilizerTest extends FunSuite with Logging
         case e: Exception =>
           (0L, 0L, 1L)
       }
+    }
+    if (doFlush) {
+      tranquilizer.flush()
     }
     Await.result(Future.collect(futures)).foldLeft((0L, 0L, 0L)) { (a, b) =>
       (a._1 + b._1, a._2 + b._2, a._3 + b._3)
@@ -82,6 +94,23 @@ class TranquilizerTest extends FunSuite with Logging
       newTranquilizer(beam, maxBatchSize, maxPendingBatches, lingerMillis).withFinally(_._1.stop()) {
         case (tranquilizer, desc) =>
           val (acked, dropped, failed) = doSend(tranquilizer, Seq("hey", "what"))
+          assert(acked === 2, "acked (%s)" format desc)
+          assert(dropped === 0, "dropped (%s)" format desc)
+          assert(failed === 0, "failed (%s)" format desc)
+          assert(
+            MemoryBeam.get("foo") === Seq(Dict("bar" -> "hey"), Dict("bar" -> "what")),
+            "output (%s)" format desc
+          )
+      }
+    }
+  }
+
+  test("Send by flush") {
+    for (beam <- newBeams(); maxBatchSize <- Seq(100); maxPendingBatches <- Seq(1, 5); lingerMillis <- MomentsSoDear) {
+      MemoryBeam.clear()
+      newTranquilizer(beam, maxBatchSize, maxPendingBatches, lingerMillis).withFinally(_._1.stop()) {
+        case (tranquilizer, desc) =>
+          val (acked, dropped, failed) = doSend(tranquilizer, Seq("hey", "what"), true)
           assert(acked === 2, "acked (%s)" format desc)
           assert(dropped === 0, "dropped (%s)" format desc)
           assert(failed === 0, "failed (%s)" format desc)
@@ -200,6 +229,51 @@ class TranquilizerTest extends FunSuite with Logging
           )
       }
     }
+  }
+
+  test("Multithreaded batch sends") {
+    for {
+      beam <- Seq(newDelayedMemoryBeam(50, 0.2))
+      maxBatchSize <- Seq(2000)
+      maxPendingBatches <- Seq(1, 5)
+      lingerMillis <- Seq(0, 100)
+    } {
+      MemoryBeam.clear()
+      val exec = Executors.newFixedThreadPool(8, new ThreadFactoryBuilder().setDaemon(true).build())
+      val allAcked = new AtomicLong
+      val sender = Tranquilizer.create(beam, maxBatchSize, maxPendingBatches, lingerMillis)
+      sender.start()
+      val futures = for (i <- 0 until 8) yield {
+        exec.submit(
+          new Runnable
+          {
+            override def run(): Unit = {
+              val acked = new AtomicLong
+              val failed = new AtomicLong
+
+              for (j <- 0 until 40003) {
+                sender.send("x") respond {
+                  case Return(_) => acked.incrementAndGet()
+                  case Throw(e) => failed.incrementAndGet()
+                }
+              }
+
+              sender.flush()
+              if (failed.get() == 0) {
+                allAcked.addAndGet(acked.get())
+              }
+            }
+          }
+        )
+      }
+
+      futures foreach (_.get())
+      exec.shutdown()
+      exec.awaitTermination(10, TimeUnit.MINUTES)
+      sender.stop()
+      assert(allAcked.get() === 40003 * 8)
+    }
+
   }
 }
 


### PR DESCRIPTION
Fixes #85