### PR TITLE
IndexService: close should return a future, and should not attempt to close a client that has not been created yet.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -564,7 +564,7 @@ object DruidBeams
       {
         override def sendBatch(events: Seq[EventType]) = clusteredBeam.sendBatch(events)
 
-        override def close() = clusteredBeam.close() map (_ => indexService.close())
+        override def close() = clusteredBeam.close() flatMap (_ => indexService.close())
 
         override def toString = clusteredBeam.toString
       }


### PR DESCRIPTION
I think this should fix the issue reported in https://groups.google.com/d/topic/druid-development/nCMp7JCNhuo/discussion