### PR TITLE
Disable Finagle fail-fast behavior by default.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistryConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/finagle/FinagleRegistryConfig.scala
@@ -23,7 +23,7 @@ import org.scala_tools.time.Imports._
 case class FinagleRegistryConfig(
   finagleHttpTimeout: Period = 90.seconds,
   finagleHttpConnectionsPerHost: Int = 2,
-  finagleEnableFailFast: Boolean = true
+  finagleEnableFailFast: Boolean = false
 )
 
 object FinagleRegistryConfig


### PR DESCRIPTION
Fixes #50

since our groups all just have one host in them, according to https://twitter.github.io/finagle/guide/Clients.html#client-fail-fast we should disable fail-fast.