### PR TITLE
Optionally locate Druid tasks through "runningTasks" endpoint on the overlord.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
@@ -98,6 +98,15 @@ abstract class PropertiesBasedConfig(
   @Config(Array("druidBeam.firehoseBufferSize"))
   def firehoseBufferSize: Int = DruidBeamConfig().firehoseBufferSize
 
+  @Config(Array("druidBeam.overlordLocator"))
+  def overlordLocator = DruidBeamConfig().overlordLocator
+
+  @Config(Array("druidBeam.taskLocator"))
+  def taskLocator = DruidBeamConfig().taskLocator
+
+  @Config(Array("druidBeam.overlordPollPeriod"))
+  def overlordPollPeriod = DruidBeamConfig().overlordPollPeriod
+
   def druidBeamConfig: DruidBeamConfig = DruidBeamConfig.builder()
     .firehoseGracePeriod(firehoseGracePeriod)
     .firehoseQuietPeriod(firehoseQuietPeriod)
@@ -106,6 +115,9 @@ abstract class PropertiesBasedConfig(
     .randomizeTaskId(randomizeTaskId)
     .indexRetryPeriod(indexRetryPeriod)
     .firehoseBufferSize(firehoseBufferSize)
+    .overlordLocator(overlordLocator)
+    .taskLocator(taskLocator)
+    .overlordPollPeriod(overlordPollPeriod)
     .build()
 
   override def discoAnnounce: Option[DiscoAnnounceConfig] = None

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
@@ -41,7 +41,7 @@ class DruidBeam[A](
   private[druid] val tasks: Seq[TaskPointer],
   location: DruidLocation,
   config: DruidBeamConfig,
-  finagleRegistry: FinagleRegistry,
+  taskLocator: TaskLocator,
   indexService: IndexService,
   emitter: ServiceEmitter,
   objectWriter: ObjectWriter[A]
@@ -50,11 +50,10 @@ class DruidBeam[A](
   private[this] val clients = Map(
     tasks map {
       task =>
-        val service = location.environment.firehoseServicePattern format task.serviceKey
         task ->
           new TaskClient(
             task,
-            finagleRegistry.checkout(service),
+            taskLocator.connect(task),
             location.dataSource,
             config.firehoseQuietPeriod,
             config.firehoseRetryPeriod,

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamConfig.scala
@@ -27,7 +27,10 @@ case class DruidBeamConfig(
   firehoseChunkSize: Int = 1000,
   randomizeTaskId: Boolean = false,
   indexRetryPeriod: Period = 1.minute,
-  firehoseBufferSize: Int = 100000
+  firehoseBufferSize: Int = 100000,
+  overlordLocator: String = OverlordLocator.Curator,
+  taskLocator: String = TaskLocator.Curator,
+  overlordPollPeriod: Period = 20.seconds
 ) extends IndexServiceConfig
 
 object DruidBeamConfig
@@ -94,6 +97,27 @@ object DruidBeamConfig
       * Default is 100000.
       */
     def firehoseBufferSize(x: Int) = new Builder(config.copy(firehoseBufferSize = x))
+
+    /**
+      * Strategy for locating the Druid Overlord. Can be "curator".
+      *
+      * Default is "curator".
+      */
+    def overlordLocator(x: String) = new Builder(config.copy(overlordLocator = x))
+
+    /**
+      * Strategy for locating Druid tasks. Can be "curator" or "overlord".
+      *
+      * Default is "curator".
+      */
+    def taskLocator(x: String) = new Builder(config.copy(taskLocator = x))
+
+    /**
+      * How often to poll the Overlord for task locations. Only applies if taskLocator is "overlord".
+      *
+      * Default is 20 seconds.
+      */
+    def overlordPollPeriod(x: Period) = new Builder(config.copy(overlordPollPeriod = x))
 
     def build(): DruidBeamConfig = config
   }

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamMaker.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamMaker.scala
@@ -26,7 +26,6 @@ import com.metamx.common.scala.untyped._
 import com.metamx.emitter.service.ServiceEmitter
 import com.metamx.tranquility.beam.BeamMaker
 import com.metamx.tranquility.beam.ClusteredBeamTuning
-import com.metamx.tranquility.finagle.FinagleRegistry
 import com.metamx.tranquility.typeclass.ObjectWriter
 import com.twitter.util.Await
 import com.twitter.util.Future
@@ -45,7 +44,7 @@ class DruidBeamMaker[A](
   druidTuningMap: Dict,
   rollup: DruidRollup,
   timestampSpec: TimestampSpec,
-  finagleRegistry: FinagleRegistry,
+  taskLocator: TaskLocator,
   indexService: IndexService,
   emitter: ServiceEmitter,
   objectWriter: ObjectWriter[A],
@@ -172,7 +171,7 @@ class DruidBeamMaker[A](
       tasks,
       location,
       config,
-      finagleRegistry,
+      taskLocator,
       indexService,
       emitter,
       objectWriter
@@ -216,7 +215,7 @@ class DruidBeamMaker[A](
       tasks,
       location,
       config,
-      finagleRegistry,
+      taskLocator,
       indexService,
       emitter,
       objectWriter

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidEnvironment.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidEnvironment.scala
@@ -24,7 +24,8 @@ class DruidEnvironment(
 ) extends Equals
 {
   // Replace / with : just like Druid does.
-  val indexService = indexServiceMaybeWithSlashes.replace('/', ':')
+  // See Druid code at https://github.com/druid-io/druid/blob/62ba9ade37f2ab96d3894a0eb622ed5e4f290a03/server/src/main/java/io/druid/curator/discovery/CuratorServiceUtils.java
+  val indexServiceKey: String = indexServiceMaybeWithSlashes.replace('/', ':')
 
   // Sanity check on firehoseServicePattern.
   require(firehoseServicePattern.contains("%s"), "firehoseServicePattern must contain '%s' somewhere")
@@ -34,11 +35,11 @@ class DruidEnvironment(
 
   override def equals(other: Any) = other match {
     case that: DruidEnvironment =>
-      (indexService, firehoseServicePattern) ==(that.indexService, that.firehoseServicePattern)
+      (indexServiceKey, firehoseServicePattern) ==(that.indexServiceKey, that.firehoseServicePattern)
     case _ => false
   }
 
-  override def hashCode = (indexService, firehoseServicePattern).hashCode()
+  override def hashCode = (indexServiceKey, firehoseServicePattern).hashCode()
 }
 
 object DruidEnvironment

--- a/core/src/main/scala/com/metamx/tranquility/druid/OverlordLocator.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/OverlordLocator.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.druid
+
+import com.metamx.common.scala.net.curator.Disco
+import com.metamx.common.scala.net.finagle.DiscoResolver
+import com.metamx.tranquility.finagle.FinagleRegistry
+import com.twitter.finagle.Resolver
+import com.twitter.finagle.Service
+import com.twitter.finagle.http
+import com.twitter.finagle.http.Request
+import com.twitter.finagle.http.Response
+
+trait OverlordLocator
+{
+  def maybeAddResolvers(disco: () => Disco): Unit
+
+  def connect(): Service[http.Request, http.Response]
+}
+
+class CuratorOverlordLocator(
+  finagleRegistry: FinagleRegistry,
+  druidEnvironment: DruidEnvironment
+) extends OverlordLocator
+{
+  override def maybeAddResolvers(disco: () => Disco): Unit = {
+    if (!finagleRegistry.schemes.contains("disco")) {
+      finagleRegistry.addResolver(new DiscoResolver(disco()))
+    }
+  }
+
+  override def connect(): Service[Request, Response] = {
+    finagleRegistry.connect("disco", druidEnvironment.indexServiceKey)
+  }
+}
+
+object OverlordLocator
+{
+  val Curator = "curator"
+
+  private[tranquility] def create(
+    kind: String,
+    finagleRegistry: FinagleRegistry,
+    druidEnvironment: DruidEnvironment
+  ): OverlordLocator =
+  {
+    kind match {
+      case `Curator` => new CuratorOverlordLocator(finagleRegistry, druidEnvironment)
+      case _ => throw new IllegalArgumentException(s"Locator[$kind] is not a recognized kind of OverlordLocator.")
+    }
+  }
+}

--- a/core/src/main/scala/com/metamx/tranquility/druid/TaskLocator.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/TaskLocator.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.druid
+
+import com.metamx.common.scala.net.curator.Disco
+import com.metamx.common.scala.net.finagle.DiscoResolver
+import com.metamx.tranquility.finagle.DruidTaskResolver
+import com.metamx.tranquility.finagle.FinagleRegistry
+import com.twitter.finagle.Service
+import com.twitter.finagle.http
+
+trait TaskLocator
+{
+  def maybeAddResolvers(disco: () => Disco, druidTaskResolver: () => DruidTaskResolver): Unit
+
+  def connect(taskPointer: TaskPointer): Service[http.Request, http.Response]
+}
+
+class CuratorTaskLocator(
+  finagleRegistry: FinagleRegistry,
+  druidEnvironment: DruidEnvironment
+) extends TaskLocator
+{
+  override def maybeAddResolvers(disco: () => Disco, druidTaskResolver: () => DruidTaskResolver): Unit = {
+    if (!finagleRegistry.schemes.contains("disco")) {
+      finagleRegistry.addResolver(new DiscoResolver(disco()))
+    }
+  }
+
+  override def connect(taskPointer: TaskPointer): Service[http.Request, http.Response] =
+  {
+    val service = druidEnvironment.firehoseServicePattern format taskPointer.serviceKey
+    finagleRegistry.connect("disco", service)
+  }
+}
+
+class OverlordTaskLocator(
+  finagleRegistry: FinagleRegistry,
+  druidEnvironment: DruidEnvironment
+) extends TaskLocator
+{
+  override def maybeAddResolvers(disco: () => Disco, druidTaskResolver: () => DruidTaskResolver): Unit = {
+    if (!finagleRegistry.schemes.contains("disco")) {
+      finagleRegistry.addResolver(new DiscoResolver(disco()))
+    }
+
+    val dtrScheme = DruidTaskResolver.mkscheme(druidEnvironment.indexServiceKey)
+
+    if (!finagleRegistry.schemes.contains(dtrScheme)) {
+      val resolver = druidTaskResolver()
+      require(
+        resolver.scheme == dtrScheme,
+        s"WTF?! DruidTaskResolver scheme[${resolver.scheme}] did not match expected scheme[$dtrScheme]"
+      )
+      finagleRegistry.addResolver(resolver)
+    }
+  }
+
+  override def connect(taskPointer: TaskPointer): Service[http.Request, http.Response] =
+  {
+    finagleRegistry.connect(DruidTaskResolver.mkscheme(druidEnvironment.indexServiceKey), taskPointer.id)
+  }
+}
+
+object TaskLocator
+{
+  val Curator  = "curator"
+  val Overlord = "overlord"
+
+  private[tranquility] def create(
+    kind: String,
+    finagleRegistry: FinagleRegistry,
+    druidEnvironment: DruidEnvironment
+  ): TaskLocator =
+  {
+    kind match {
+      case `Curator` => new CuratorTaskLocator(finagleRegistry, druidEnvironment)
+      case `Overlord` => new OverlordTaskLocator(finagleRegistry, druidEnvironment)
+      case _ => throw new IllegalArgumentException(s"Locator[$kind] is not a recognized kind of TaskLocator.")
+    }
+  }
+}

--- a/core/src/main/scala/com/metamx/tranquility/finagle/DruidTaskResolver.scala
+++ b/core/src/main/scala/com/metamx/tranquility/finagle/DruidTaskResolver.scala
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.finagle
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.metamx.common.scala.Logging
+import com.metamx.common.scala.timekeeper.Timekeeper
+import com.metamx.tranquility.druid.IndexService
+import com.twitter.finagle.Addr
+import com.twitter.finagle.Resolver
+import com.twitter.util.Await
+import com.twitter.util.Closable
+import com.twitter.util.Future
+import com.twitter.util.Time
+import com.twitter.util.Updatable
+import com.twitter.util.Var
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import org.scala_tools.time.Imports._
+import scala.util.Random
+import scala.util.control.NonFatal
+
+class DruidTaskResolver(
+  indexService: IndexService,
+  timekeeper: Timekeeper,
+  pollPeriod: Period
+) extends Resolver with Logging
+{
+  private val pollExecutor = Executors.newSingleThreadExecutor(
+    new ThreadFactoryBuilder().setNameFormat(s"DruidTaskResolver[$indexService]").setDaemon(true).build()
+  )
+
+  private val started      = new AtomicBoolean
+  private val taskNumberer = new AtomicLong
+
+  private val lock     = new AnyRef
+  private var nextPoll = 0L
+  private var tasks    = Map[Long, (String, AtomicReference[Addr], Updatable[Addr])]()
+
+  private def ensureStarted() {
+    if (started.compareAndSet(false, true)) {
+      log.info(s"Starting poll thread for indexService[$indexService], pollPeriod[$pollPeriod].")
+      pollExecutor.submit(
+        new Runnable
+        {
+          override def run(): Unit = {
+            while (!Thread.currentThread().isInterrupted) {
+              try {
+                val tasksSnapshot: Map[Long, (String, AtomicReference[Addr], Updatable[Addr])] = lock.synchronized {
+                  while (timekeeper.now.millis < nextPoll) {
+                    val waitMillis = nextPoll - timekeeper.now.millis
+                    if (waitMillis > 0) {
+                      lock.wait(waitMillis)
+                    }
+                  }
+                  tasks
+                }
+
+                val now = timekeeper.now
+                val baseWait = now.plus(pollPeriod).millis - now.millis
+                val fuzzyWait = (math.max(1 + 0.25 * Random.nextGaussian, 0) * baseWait).toLong
+                nextPoll = now.millis + fuzzyWait
+
+                val running = Await.result(indexService.runningTasks())
+
+                log.info(s"Polled[$indexServiceKey] and found ${running.size} tasks " +
+                  s"(${running.count(_._2.isBound)} bound).")
+
+                for ((taskNumber, (taskId, addr, updatable)) <- tasksSnapshot) {
+                  val runningHostPort = running.get(taskId)
+                  val runningAddr: Addr = runningHostPort.map(_.toAddr).getOrElse(Addr.Neg)
+                  if (addr.get() != runningAddr) {
+                    log.info(s"Updating location for task[$taskId] (#$taskNumber) to[$runningAddr].")
+                    addr.set(runningAddr)
+                    updatable.update(runningAddr)
+                  }
+                }
+              }
+              catch {
+                case NonFatal(e) =>
+                  log.warn(e, s"Poll failed, trying again at[${new DateTime(nextPoll)}].")
+              }
+            }
+          }
+        }
+      )
+    }
+  }
+
+  override val scheme = DruidTaskResolver.mkscheme(indexService.key)
+
+  override def bind(taskId: String) = {
+    val taskNumber = taskNumberer.incrementAndGet()
+
+    Var.async[Addr](Addr.Pending) {
+      updatable =>
+        log.info(s"Started monitoring task[$taskId] (#$taskNumber).")
+
+        lock.synchronized {
+          nextPoll = 0L
+          tasks = tasks + (taskNumber ->(taskId, new AtomicReference[Addr], updatable))
+          lock.notifyAll()
+        }
+
+        ensureStarted()
+        new Closable
+        {
+          override def close(deadline: Time): Future[Unit] = {
+            lock.synchronized {
+              log.info(s"Stopped monitoring task[$taskId] (#$taskNumber).")
+              tasks = tasks - taskNumber
+              Future.Done
+            }
+          }
+        }
+    }
+  }
+
+  def indexServiceKey: String = indexService.key
+}
+
+object DruidTaskResolver
+{
+  def mkscheme(indexServiceKey: String) = s"druidTask!$indexServiceKey"
+}

--- a/core/src/test/resources/example.json
+++ b/core/src/test/resources/example.json
@@ -71,6 +71,8 @@
   "properties": {
     "zookeeper.connect": "localhost:2181",
     "druid.selectors.indexing.serviceName": "druid/overlord",
-    "druid.discovery.curator.path": "/druid/discovery"
+    "druid.discovery.curator.path": "/druid/discovery",
+    "druidBeam.taskLocator": "overlord",
+    "druidBeam.overlordPollPeriod": "PT5S"
   }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,22 +73,25 @@ Any of these properties can be specified either globally, or per-dataSource.
 |--------|-----------|-------|
 |`druid.discovery.curator.path`|Curator service discovery path.|/druid/discovery|
 |`druid.selectors.indexing.serviceName`|The druid.service name of the indexing service Overlord node.|druid/overlord|
-|`task.partitions`|Number of Druid partitions to create.|1|
-|`task.replicants`|Number of instances of each Druid partition to create. This is the *total* number of instances, so 2 replicants means 2 tasks will be created.|1|
-|`task.warmingPeriod`|If nonzero, create Druid tasks early. This can be useful if tasks take a long time to start up in your environment.|PT0M|
-|`zookeeper.connect`|ZooKeeper connect string.|none; must be provided|
-|`zookeeper.timeout`|ZooKeeper session timeout. ISO8601 duration.|PT20S|
-|`tranquility.blockOnFull`|Whether "send" will block (true) or throw an exception (false) when called while the outgoing queue is full.|true|
-|`tranquility.lingerMillis`|Wait this long for batches to collect more messages (up to maxBatchSize) before sending them. Set to zero to disable waiting.|0|
-|`tranquility.maxBatchSize`|Maximum number of messages to send at once.|2000|
-|`tranquility.maxPendingBatches`|Maximum number of batches that may be in flight before we block and wait for one to finish.|5|
 |`druidBeam.firehoseBufferSize`|Size of buffer used by firehose to store events.|100000|
 |`druidBeam.firehoseChunkSize`|Maximum number of events to send to Druid in one HTTP request.|1000|
 |`druidBeam.firehoseGracePeriod`|Druid indexing tasks will shut down this long after the windowPeriod has elapsed.|PT5M|
 |`druidBeam.firehoseQuietPeriod`|Wait this long for a task to appear before complaining that it cannot be found.|PT1M|
 |`druidBeam.firehoseRetryPeriod`|Retry for this long before complaining that events could not be pushed|PT1M|
 |`druidBeam.indexRetryPeriod`|If an indexing service overlord call fails for some apparently-transient reason, retry for this long before giving up.|PT1M|
+|`druidBeam.overlordLocator`|Strategy for locating the Druid Overlord. Can be "curator".|curator|
+|`druidBeam.overlordPollPeriod`|How often to poll the Overlord for task locations. Only applies if taskLocator is "overlord".|PT20S|
 |`druidBeam.randomizeTaskId`|True if we should add a random suffix to Druid task IDs. This is useful for testing.|false|
+|`druidBeam.taskLocator`|Strategy for locating Druid tasks. Can be "curator" or "overlord".|curator|
+|`task.partitions`|Number of Druid partitions to create.|1|
+|`task.replicants`|Number of instances of each Druid partition to create. This is the *total* number of instances, so 2 replicants means 2 tasks will be created.|1|
+|`task.warmingPeriod`|If nonzero, create Druid tasks early. This can be useful if tasks take a long time to start up in your environment.|PT0M|
+|`tranquility.blockOnFull`|Whether "send" will block (true) or throw an exception (false) when called while the outgoing queue is full.|true|
+|`tranquility.lingerMillis`|Wait this long for batches to collect more messages (up to maxBatchSize) before sending them. Set to zero to disable waiting.|0|
+|`tranquility.maxBatchSize`|Maximum number of messages to send at once.|2000|
+|`tranquility.maxPendingBatches`|Maximum number of batches that may be in flight before we block and wait for one to finish.|5|
+|`zookeeper.connect`|ZooKeeper connect string.|none; must be provided|
+|`zookeeper.timeout`|ZooKeeper session timeout. ISO8601 duration.|PT20S|
 
 ### Code
 


### PR DESCRIPTION
Requires druid-io/druid#2419

This is enabled by setting druidBeam.taskLocator=overlord, and works by polling the
overlord in a background thread. Also added a useless setting for
druidBeam.overlordLocator, which might not be useless in the future if we ever have
a way to do that without Curator discovery (perhaps a hard-coded list, or a DNS name).

No integration tests yet, since the Druid code that enables this is not yet in a
Maven release so we cannot pull it in.