### PR TITLE
Tranquilizer blockOnFull option, Server async api

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/tranquilizer/Tranquilizer.scala
+++ b/core/src/main/scala/com/metamx/tranquility/tranquilizer/Tranquilizer.scala
@@ -51,7 +51,8 @@ class Tranquilizer[MessageType] private(
   beam: Beam[MessageType],
   maxBatchSize: Int,
   maxPendingBatches: Int,
-  lingerMillis: Long
+  lingerMillis: Long,
+  blockOnFull: Boolean
 ) extends Service[MessageType, Unit] with Logging
 {
   require(maxBatchSize >= 1, "batchSize >= 1")
@@ -136,6 +137,7 @@ class Tranquilizer[MessageType] private(
 
   /**
     * Same as [[Tranquilizer.send]].
+    *
     * @param message the message to send
     * @return a future that resolves when the message is sent
     */
@@ -153,6 +155,7 @@ class Tranquilizer[MessageType] private(
     *
     * @param message message to send
     * @return future that resolves when the message is sent, or fails to send
+    * @throws BufferFullException if outgoing queue is full and blockOnFull is false.
     */
   def send(message: MessageType): Future[Unit] = {
     requireStarted()
@@ -163,13 +166,17 @@ class Tranquilizer[MessageType] private(
 
     val (exIndexBufferPair, future) = lock.synchronized {
       while (buffer.size >= maxBatchSize - 1 && pendingBatches.size >= maxPendingBatches) {
-        if (log.isDebugEnabled) {
-          log.debug(
-            s"Buffer size[${buffer.size}] >= maxBatchSize[$maxBatchSize] - 1 and " +
-              s"pendingBatches[${pendingBatches.size}] >= maxPendingBatches[$maxPendingBatches], waiting..."
-          )
+        if (blockOnFull) {
+          if (log.isDebugEnabled) {
+            log.debug(
+              s"Buffer size[${buffer.size}] >= maxBatchSize[$maxBatchSize] - 1 and " +
+                s"pendingBatches[${pendingBatches.size}] >= maxPendingBatches[$maxPendingBatches], waiting..."
+            )
+          }
+          lock.wait()
+        } else {
+          throw new BufferFullException
         }
-        lock.wait()
       }
 
       if (buffer.isEmpty) {
@@ -331,27 +338,35 @@ class Tranquilizer[MessageType] private(
   * Exception indicating that a message was dropped "on purpose" by the beam. This is not a recoverable exception
   * and so the message must be discarded.
   */
-class MessageDroppedException private() extends Exception with com.twitter.finagle.NoStacktrace
+class MessageDroppedException private() extends Exception("Message dropped") with com.twitter.finagle.NoStacktrace
 
 object MessageDroppedException
 {
   val instance = new MessageDroppedException
 }
 
+/**
+  * Exception indicating that the outgoing buffer was full. Will only be thrown if "blockOnFull" is false.
+  */
+class BufferFullException extends Exception("Buffer full")
+
 object Tranquilizer
 {
   val DefaultMaxBatchSize      = 2000
   val DefaultMaxPendingBatches = 5
   val DefaultLingerMillis      = 0L
+  val DefaultLingerMillis      = 0
+  val DefaultBlockOnFull       = true
 
   def apply[MessageType](
     beam: Beam[MessageType],
     maxBatchSize: Int = DefaultMaxBatchSize,
     maxPendingBatches: Int = DefaultMaxPendingBatches,
-    lingerMillis: Long = DefaultLingerMillis
+    lingerMillis: Long = DefaultLingerMillis,
+    blockOnFull: Boolean = DefaultBlockOnFull
   ): Tranquilizer[MessageType] =
   {
-    new Tranquilizer[MessageType](beam, maxBatchSize, maxPendingBatches, lingerMillis)
+    new Tranquilizer[MessageType](beam, maxBatchSize, maxPendingBatches, lingerMillis, blockOnFull)
   }
 
   /**
@@ -367,18 +382,21 @@ object Tranquilizer
       beam,
       DefaultMaxBatchSize,
       DefaultMaxPendingBatches,
-      DefaultLingerMillis
+      DefaultLingerMillis,
+      DefaultBlockOnFull
     )
   }
 
   /**
     * Wraps a Beam and exposes a single-message-future API. Thread-safe.
     *
-    * @param beam The wrapped Beam.
-    * @param maxBatchSize Maximum number of messages to send at once.
+    * Does not support all options; for the full set of options, use a "builder".
+    *
+    * @param beam              The wrapped Beam.
+    * @param maxBatchSize      Maximum number of messages to send at once.
     * @param maxPendingBatches Maximum number of batches that may be in flight before we block and wait for one to finish.
-    * @param lingerMillis Wait this long for batches to collect more messages (up to maxBatchSize) before sending them.
-    *                     Set to zero to disable waiting.
+    * @param lingerMillis      Wait this long for batches to collect more messages (up to maxBatchSize) before sending them.
+    *                          Set to zero to disable waiting.
     */
   def create[MessageType](
     beam: Beam[MessageType],
@@ -387,7 +405,7 @@ object Tranquilizer
     lingerMillis: Long
   ): Tranquilizer[MessageType] =
   {
-    new Tranquilizer[MessageType](beam, maxBatchSize, maxPendingBatches, lingerMillis)
+    new Tranquilizer[MessageType](beam, maxBatchSize, maxPendingBatches, lingerMillis, DefaultBlockOnFull)
   }
 
   /**
@@ -400,13 +418,15 @@ object Tranquilizer
   private case class Config(
     maxBatchSize: Int = DefaultMaxBatchSize,
     maxPendingBatches: Int = DefaultMaxPendingBatches,
-    lingerMillis: Long = DefaultLingerMillis
+    lingerMillis: Long = DefaultLingerMillis,
+    blockOnFull: Boolean = DefaultBlockOnFull
   )
 
   class Builder private[tranquilizer](config: Config)
   {
     /**
       * Maximum number of messages to send at once. Optional, default is 5000.
+      *
       * @param n max batch size
       * @return new builder
       */
@@ -417,6 +437,7 @@ object Tranquilizer
     /**
       * Maximum number of batches that may be in flight before we block and wait for one to finish. Optional, default
       * is 5.
+      *
       * @param n max pending batches
       * @return new builder
       */
@@ -427,6 +448,7 @@ object Tranquilizer
     /**
       * Wait this long for batches to collect more messages (up to maxBatchSize) before sending them. Set to zero to
       * disable waiting. Optional, default is zero.
+      *
       * @param n linger millis
       * @return new builder
       */
@@ -435,13 +457,33 @@ object Tranquilizer
     }
 
     /**
+      * Whether "send" will block (true) or throw an exception (false) when called while the outgoing queue is full.
+      * Optional, default is true.
+      *
+      * @param b flag for blocking when full
+      * @return new builder
+      */
+    def blockOnFull(b: Boolean) = {
+      new Builder(config.copy(blockOnFull = b))
+    }
+
+    /**
       * Build a Tranquilizer.
+      *
       * @param beam beam to wrap
       * @return tranquilizer
       */
     def build[MessageType](beam: Beam[MessageType]): Tranquilizer[MessageType] = {
-      new Tranquilizer[MessageType](beam, config.maxBatchSize, config.maxPendingBatches, config.lingerMillis)
+      new Tranquilizer[MessageType](
+        beam,
+        config.maxBatchSize,
+        config.maxPendingBatches,
+        config.lingerMillis,
+        config.blockOnFull
+      )
     }
+
+    override def toString = s"Tranquilizer.Builder($Config)"
   }
 
 }

--- a/core/src/main/scala/com/metamx/tranquility/tranquilizer/Tranquilizer.scala
+++ b/core/src/main/scala/com/metamx/tranquility/tranquilizer/Tranquilizer.scala
@@ -355,7 +355,6 @@ object Tranquilizer
   val DefaultMaxBatchSize      = 2000
   val DefaultMaxPendingBatches = 5
   val DefaultLingerMillis      = 0L
-  val DefaultLingerMillis      = 0
   val DefaultBlockOnFull       = true
 
   def apply[MessageType](

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,16 +78,17 @@ Any of these properties can be specified either globally, or per-dataSource.
 |`task.warmingPeriod`|If nonzero, create Druid tasks early. This can be useful if tasks take a long time to start up in your environment.|PT0M|
 |`zookeeper.connect`|ZooKeeper connect string.|none; must be provided|
 |`zookeeper.timeout`|ZooKeeper session timeout. ISO8601 duration.|PT20S|
+|`tranquility.blockOnFull`|Whether "send" will block (true) or throw an exception (false) when called while the outgoing queue is full.|true|
+|`tranquility.lingerMillis`|Wait this long for batches to collect more messages (up to maxBatchSize) before sending them. Set to zero to disable waiting.|0|
 |`tranquility.maxBatchSize`|Maximum number of messages to send at once.|2000|
 |`tranquility.maxPendingBatches`|Maximum number of batches that may be in flight before we block and wait for one to finish.|5|
-|`tranquility.lingerMillis`|Wait this long for batches to collect more messages (up to maxBatchSize) before sending them. Set to zero to disable waiting.|0|
+|`druidBeam.firehoseBufferSize`|Size of buffer used by firehose to store events.|100000|
+|`druidBeam.firehoseChunkSize`|Maximum number of events to send to Druid in one HTTP request.|1000|
 |`druidBeam.firehoseGracePeriod`|Druid indexing tasks will shut down this long after the windowPeriod has elapsed.|PT5M|
 |`druidBeam.firehoseQuietPeriod`|Wait this long for a task to appear before complaining that it cannot be found.|PT1M|
 |`druidBeam.firehoseRetryPeriod`|Retry for this long before complaining that events could not be pushed|PT1M|
-|`druidBeam.firehoseChunkSize`|Maximum number of events to send to Druid in one HTTP request.|1000|
-|`druidBeam.randomizeTaskId`|True if we should add a random suffix to Druid task IDs. This is useful for testing.|false|
 |`druidBeam.indexRetryPeriod`|If an indexing service overlord call fails for some apparently-transient reason, retry for this long before giving up.|PT1M|
-|`druidBeam.firehoseBufferSize`|Size of buffer used by firehose to store events.|100000|
+|`druidBeam.randomizeTaskId`|True if we should add a random suffix to Druid task IDs. This is useful for testing.|false|
 
 ### Code
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -31,7 +31,34 @@ Where *received* is the number of messages you sent to the server, and *sent* is
 successfully sent along to Druid. This may be fewer than the number of messages received if some of them were dropped
 due to e.g. being outside the windowPeriod.
 
+This API is synchronous and will block until your messages are either sent to Druid, or have failed to send.
+
 If there is an error sending the data, you will get an HTTP error code (4xx or 5xx).
+
+### Asynchronous HTTP API
+
+Tranquility Server also offers an asynchronous API. The form of the request should be the same as the synchronous API,
+but you should use the URLs `/v1/post-async` or `/v1/post-async/DATASOURCE`.
+
+The response will be:
+
+```json
+{
+  "result": {
+    "received": 10,
+    "sent": 0
+  }
+}
+```
+
+Note that "sent" will always be 0 when using the asynchronous API.
+
+If the server's outgoing message queue fills up, your requests will either block or fail. To control this behavior,
+set the `tranquility.blockOnFull` property to either true or false. If you set this to "false" and your server's
+outgoing queue is full, you will get an HTTP 503.
+
+With either the synchronous or asynchronous APIs, you can adjust the size of your Tranquility Server's message queues
+through the properties `tranquility.maxBatchSize` and `tranquility.maxPendingBatches`.
 
 ## Setup
 

--- a/server/src/test/scala/com/metamx/tranquility/server/ServerTestUtil.scala
+++ b/server/src/test/scala/com/metamx/tranquility/server/ServerTestUtil.scala
@@ -50,6 +50,7 @@ object ServerTestUtil
     }
     finally {
       tester.stop()
+      tranquilizers.values.foreach(_.flush())
       tranquilizers.values.foreach(_.stop())
     }
   }


### PR DESCRIPTION
- Tranquilizer: Add blockOnFull flag to control behavior when outgoing queue is full.
- Server: Add async api.

Fixes #87