### PR TITLE
Server: Raise default http.threads.

### DIFF
--- a/distribution/src/universal/conf/server.json.example
+++ b/distribution/src/universal/conf/server.json.example
@@ -54,6 +54,6 @@
    "properties" : {
       "zookeeper.connect" : "localhost",
       "http.port" : "8200",
-      "http.threads" : "8"
+      "http.threads" : "40"
    }
 }

--- a/docs/server.md
+++ b/docs/server.md
@@ -50,7 +50,7 @@ These Server-specific properties, if used, must be specified at the global level
 |Property|Description|Default|
 |--------|-----------|-------|
 |`http.port`|Port to listen on.|8200|
-|`http.threads`|Number of threads for HTTP requests.|8|
+|`http.threads`|Number of threads for serving HTTP requests.|40|
 |`http.idleTimeout`|Abort connections that have had no activity for longer than this timeout. Set to zero to disable. ISO8601 duration.|PT5M|
 
 ### Running

--- a/server/src/main/scala/com/metamx/tranquility/server/PropertiesBasedServerConfig.scala
+++ b/server/src/main/scala/com/metamx/tranquility/server/PropertiesBasedServerConfig.scala
@@ -30,7 +30,7 @@ abstract class PropertiesBasedServerConfig
   def httpPort: Int = 8200
 
   @Config(Array("http.threads"))
-  def httpThreads: Int = 8
+  def httpThreads: Int = 40
 
   @Config(Array("http.idleTimeout"))
   def httpIdleTimeout: Period = new Period("PT5M")


### PR DESCRIPTION
Jetty uses up to 8 threads for internal use (scaling based on number of processors), so
we need more than 8 threads to work on larger boxes. Higher default shouldn't be too bad
in general, so let's go with 40.