### PR TITLE
Fix 'Loss of Druid redundancy' alert 'status' field.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/TaskClient.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/TaskClient.scala
@@ -105,7 +105,7 @@ class TaskClient(
                   log, emitter, WARN, "Loss of Druid redundancy: %s" format dataSource, Dict(
                     "dataSource" -> dataSource,
                     "task" -> task.id,
-                    "status" -> client.status.toString
+                    "status" -> newStatus.toString
                   )
                 )
                 None


### PR DESCRIPTION
Should have been the task status, not the Finagle client status.