### PR TITLE
Make benchmark more honest.

### DIFF
--- a/core/src/test/resources/benchmark.json
+++ b/core/src/test/resources/benchmark.json
@@ -73,6 +73,6 @@
     "druid.selectors.indexing.serviceName": "druid/overlord",
     "druid.discovery.curator.path": "/druid/discovery",
     "tranquility.maxBatchSize": "20000",
-    "tranquility.lingerMillis": "1"
+    "tranquility.lingerMillis": "900000"
   }
 }


### PR DESCRIPTION
Increasing lingerMillis to absurd heights has the effect of forcing all the work
onto the benchmarking thread, rather than allowing some of the work to occur
in the background send thread.