### PR TITLE
DruidTaskResolver: Demote polling log message to DEBUG.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/finagle/DruidTaskResolver.scala
+++ b/core/src/main/scala/com/metamx/tranquility/finagle/DruidTaskResolver.scala
@@ -82,7 +82,7 @@ class DruidTaskResolver(
 
                 val running = Await.result(indexService.runningTasks())
 
-                log.info(s"Polled[$indexServiceKey] and found ${running.size} tasks " +
+                log.debug(s"Polled[$indexServiceKey] and found ${running.size} tasks " +
                   s"(${running.count(_._2.isBound)} bound).")
 
                 for ((taskNumber, (taskId, addr, updatable)) <- tasksSnapshot) {


### PR DESCRIPTION
This message is logged frequently and can get annoying. The "location
changed" messages remain at INFO level.