### PR TITLE
Additional logging for non-retryable responses

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/IndexService.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/IndexService.scala
@@ -104,6 +104,7 @@ class IndexService(
 
             case code =>
               // All other responses should not be retried (including non-404 client errors)
+              log.error("Non-retryable response for uri[%s] with content: %s" format (req.uri, response.contentString))
               throw new IndexServicePermanentException(
                 "Service[%s] call failed with status: %s %s" format
                   (environment.indexService, code, response.status.reason)


### PR DESCRIPTION
We faced that sometimes druid returns 4xx error code, but we can't figure out why. It would be nice to have the uri and response body in logs for further investigation of non-retryable error.