### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You only need to include the modules you are actually using.
 
 All Tranquility modules are built for both Scala 2.10 and 2.11, except for the Samza module, which is only built for
 Scala 2.10. If you're using Scala for your own code, you should choose the Tranquility build that matches your version
-of Scala. Otherwise, Scala 2.11 is recommended.
+of Scala. Otherwise, Scala 2.11 is recommended. Kafka module needs Java 1.8 to be compiled hence please check the java version of the system.
 
 This version is built to work with Druid 0.7.x and 0.8.x. If you are using Druid 0.6.x, you may want to use Tranquility
 v0.3.2, which is the most recent version built for use with Druid 0.6.x.


### PR DESCRIPTION
Kakfa needs java 8 to be compiled (master version) I was using Java 7 and I got the following error while running 'sbt compile' in the root project.

**[info] Packaging /Users/saurav/quantiply/dev-env/tranquility/target/scala-2.10/root_2.10-0.7.4-SNAPSHOT.jar ...
[info] Done packaging.
[info] Compiling 1 Java source to /Users/saurav/quantiply/dev-env/tranquility/kafka/target/scala-2.10/classes...
[error] /Users/saurav/quantiply/dev-env/tranquility/kafka/src/main/java/com/metamx/tranquility/kafka/writer/WriterController.java:58: error: cannot find symbol
[error] this.dataSourceConfigList.sort(
[error] ^
[error] symbol: method sort(>>)
[error] location: variable dataSourceConfigList of type List>
[error] 1 error
[warn] No main class detected
[warn] No main class detected**

After updating to Java 8, the compilation was successful.