### PR TITLE
DruidBeams: Respect druid.discovery.curator.path in fromConfig.

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
@@ -75,7 +75,7 @@ abstract class PropertiesBasedConfig(
   def tranquilityLingerMillis: Long = Tranquilizer.DefaultLingerMillis
 
   @Config(Array("druid.discovery.curator.path"))
-  def discoPath: String = "/druid/discovery"
+  override def discoPath: String = "/druid/discovery"
 
   @Config(Array("druidBeam.firehoseGracePeriod"))
   def firehoseGracePeriod: Period = DruidBeamConfig().firehoseGracePeriod

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -231,6 +231,7 @@ object DruidBeams
           .sessionTimeoutMs(config.propertiesBasedConfig.zookeeperTimeout.standardDuration.millis.toInt)
           .retryPolicy(new ExponentialBackoffRetry(1000, 20, 30000))
       )
+      .discoveryPath(config.propertiesBasedConfig.discoPath)
       .location(DruidLocation(environment, fireDepartment.getDataSchema.getDataSource))
       .rollup(rollup)
       .timestampSpec(timestampSpec)

--- a/core/src/test/resources/direct-druid-test.yaml
+++ b/core/src/test/resources/direct-druid-test.yaml
@@ -28,5 +28,6 @@ dataSources:
         buildV9Directly: true
 
 properties:
+  druid.discovery.curator.path: /disco-fever
   druid.selectors.indexing.serviceName: druid/tranquility/indexer
   zookeeper.connect: @ZKPLACEHOLDER@

--- a/core/src/test/resources/druid-broker.properties
+++ b/core/src/test/resources/druid-broker.properties
@@ -23,6 +23,8 @@ druid.service=druid:tranquility:broker
 
 druid.zk.service.host=:ZKCONNECT:
 
+druid.discovery.curator.path=/disco-fever
+
 druid.processing.numThreads=1
 druid.processing.buffer.sizeBytes=8388608
 

--- a/core/src/test/resources/druid-coordinator.properties
+++ b/core/src/test/resources/druid-coordinator.properties
@@ -23,6 +23,8 @@ druid.service=druid:tranquility:coordinator
 
 druid.zk.service.host=:ZKCONNECT:
 
+druid.discovery.curator.path=/disco-fever
+
 druid.metadata.storage.type=derby
 druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/var/druid/metadata.db;create=true
 druid.metadata.storage.connector.host=localhost

--- a/core/src/test/resources/druid-overlord.properties
+++ b/core/src/test/resources/druid-overlord.properties
@@ -23,6 +23,8 @@ druid.service=druid:tranquility:indexer
 
 druid.zk.service.host=:ZKCONNECT:
 
+druid.discovery.curator.path=/disco-fever
+
 druid.metadata.storage.type=derby
 druid.metadata.storage.connector.connectURI=jdbc:derby://localhost:1527/var/druid/metadata.db;create=true
 druid.metadata.storage.connector.host=localhost

--- a/core/src/test/scala/com/metamx/tranquility/test/DirectDruidTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/DirectDruidTest.scala
@@ -100,6 +100,7 @@ object DirectDruidTest
     val druidLocation = new DruidLocation(druidEnvironment, dataSource)
     DruidBeams.builder[SimpleEvent]()
       .curator(curator)
+      .discoveryPath("/disco-fever")
       .location(druidLocation)
       .rollup(rollup)
       .tuning(tuning)


### PR DESCRIPTION
Fixes #150.