### PR TITLE
Allow for overlapping tasks with tweak to cycleBucket

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamMaker.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamMaker.scala
@@ -232,10 +232,10 @@ object DruidBeamMaker
     val tsUtc = new DateTime(ts.millis, ISOChronology.getInstanceUTC)
 
     val cycleBucket = segmentGranularity match {
-      case Granularity.MINUTE => tsUtc.minuteOfHour().get
-      case Granularity.FIVE_MINUTE => tsUtc.minuteOfHour().get
-      case Granularity.TEN_MINUTE => tsUtc.minuteOfHour().get
-      case Granularity.FIFTEEN_MINUTE => tsUtc.minuteOfHour().get
+      case Granularity.MINUTE => tsUtc.hourOfDay().get % 2 * 60 + tsUtc.minuteOfHour().get // 120 groups
+      case Granularity.FIVE_MINUTE => tsUtc.hourOfDay().get % 2 * 60 + tsUtc.minuteOfHour().get // 24 groups
+      case Granularity.TEN_MINUTE => tsUtc.hourOfDay().get % 2 * 60 + tsUtc.minuteOfHour().get // 12 groups
+      case Granularity.FIFTEEN_MINUTE => tsUtc.hourOfDay().get % 2 * 60 + tsUtc.minuteOfHour().get // 8 groups
       case Granularity.HOUR => tsUtc.hourOfDay().get
       case Granularity.SIX_HOUR => tsUtc.hourOfDay().get
       case Granularity.DAY => tsUtc.dayOfMonth().get
@@ -245,6 +245,6 @@ object DruidBeamMaker
       case x => throw new IllegalArgumentException("No gross firehose id hack for granularity[%s]" format x)
     }
 
-    "%s-%02d-%04d".format(dataSource, cycleBucket, partition)
+    "%s-%03d-%04d".format(dataSource, cycleBucket, partition)
   }
 }

--- a/publish_distribution.sh
+++ b/publish_distribution.sh
@@ -1,0 +1,1 @@
+aws s3 cp ./core/target/scala-2.10/tranquility-core_2.10-0.7.4.jar s3://artifact-monetate-dev/gradle/tranquility-core_2.10-0.7.4.monetate2.jar

--- a/publish_distribution.sh
+++ b/publish_distribution.sh
@@ -1,1 +1,1 @@
-aws s3 cp ./core/target/scala-2.10/tranquility-core_2.10-0.7.4.jar s3://artifact-monetate-dev/gradle/tranquility-core_2.10-0.7.4.monetate2.jar
+aws s3 cp ./core/target/scala-2.11/tranquility-core_2.11-0.7.4.jar s3://artifact-monetate-dev/gradle/tranquility-core_2.11-0.7.4.monetate2.jar


### PR DESCRIPTION
We have a window period that causes tasks to overlap.  This is a small change to the algorithm which calculates the bucket to allow for such cases.  

Feel free to close this PR if you don't want to allow for this, or have already solved it with other enhancements.