### PR TITLE
[WIP] Add property task.startImmediately

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/beam/ClusteredBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/beam/ClusteredBeam.scala
@@ -465,6 +465,29 @@ class ClusteredBeam[EventType: Timestamper, InnerBeamType <: Beam[EventType]](
   }
 
   override def toString = "ClusteredBeam(%s)" format identifier
+
+  def ensureBeamsRunning() = {
+    val now = timekeeper.now.withZone(DateTimeZone.UTC)
+    val start = tuning.segmentBucket(now).start
+    beam(start, now)
+  }
+
+  private[this] def startWatching() {
+    var watcherThread = new Thread(new Runnable {
+      def run() {
+        while (open) {
+          // TODO: Ensure beams are running
+          Thread.sleep(1000)
+        }
+      }
+    })
+    watcherThread.start()
+  }
+
+  if (tuning.startImmediately) {
+    ensureBeamsRunning()
+    startWatching()
+  }
 }
 
 /**

--- a/core/src/main/scala/com/metamx/tranquility/beam/ClusteredBeamTuning.scala
+++ b/core/src/main/scala/com/metamx/tranquility/beam/ClusteredBeamTuning.scala
@@ -25,6 +25,7 @@ import org.joda.time.{DateTime, Period}
 case class ClusteredBeamTuning(
   segmentGranularity: Granularity = Granularity.HOUR,
   warmingPeriod: Period = new Period(0),
+  startImmediately: Boolean = false,
   windowPeriod: Period = new Period("PT10M"),
   partitions: Int = 1,
   replicants: Int = 1,
@@ -66,6 +67,14 @@ object ClusteredBeamTuning
       * Default is PT0M (off).
       */
     def warmingPeriod(x: Period) = new Builder(config.copy(warmingPeriod = x))
+
+    /**
+      * If true, does not wait for any events to start Druid tasks. This can be useful if there are not a lot of
+      * incoming events.
+      *
+      * Default is false.
+      */
+    def startImmediately(x: Boolean) = new Builder(config.copy(startImmediately = x))
 
     /**
       * Accept events this far outside of their timeline block. For example, if it's currently 1:25PM, and your
@@ -122,11 +131,12 @@ object ClusteredBeamTuning
   def create(
     segmentGranularity: Granularity,
     warmingPeriod: Period,
+    startImmediately: Boolean,
     windowPeriod: Period,
     partitions: Int,
     replicants: Int
   ): ClusteredBeamTuning =
   {
-    apply(segmentGranularity, warmingPeriod, windowPeriod, partitions, replicants, 1, 1)
+    apply(segmentGranularity, warmingPeriod, startImmediately, windowPeriod, partitions, replicants, 1, 1)
   }
 }

--- a/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
@@ -59,6 +59,9 @@ abstract class PropertiesBasedConfig(
   @Config(Array("task.warmingPeriod"))
   def taskWarmingPeriod: Period = ClusteredBeamTuning().warmingPeriod
 
+  @Config(Array("task.startImmediately"))
+  def taskStartImmediately: Boolean = ClusteredBeamTuning().startImmediately
+
   @Config(Array("serialization.format"))
   def serializationFormat: String = "json"
 

--- a/core/src/test/scala/com/metamx/tranquility/test/DirectDruidTest.scala
+++ b/core/src/test/scala/com/metamx/tranquility/test/DirectDruidTest.scala
@@ -89,7 +89,7 @@ object DirectDruidTest
 
   def newBuilder(curator: CuratorFramework, timekeeper: Timekeeper): DruidBeams.Builder[SimpleEvent, SimpleEvent] = {
     val dataSource = "xxx"
-    val tuning = ClusteredBeamTuning(Granularity.HOUR, 0.minutes, 10.minutes, 1, 1, 1, 1)
+    val tuning = ClusteredBeamTuning(Granularity.HOUR, 0.minutes, false, 10.minutes, 1, 1, 1, 1)
     val rollup = DruidRollup(
       SpecificDruidDimensions(
         Vector("foo"),

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -87,6 +87,7 @@ Any of these properties can be specified either globally, or per-dataSource.
 |`task.partitions`|Number of Druid partitions to create.|1|
 |`task.replicants`|Number of instances of each Druid partition to create. This is the *total* number of instances, so 2 replicants means 2 tasks will be created.|1|
 |`task.warmingPeriod`|If nonzero, create Druid tasks early. This can be useful if tasks take a long time to start up in your environment.|PT0M|
+|`task.startImmediately`|If true, does not wait for any events to start Druid tasks. This can be useful if there are not a lot of incoming events.|false|
 |`tranquility.blockOnFull`|Whether "send" will block (true) or throw an exception (false) when called while the outgoing queue is full.|true|
 |`tranquility.lingerMillis`|Wait this long for batches to collect more messages (up to maxBatchSize) before sending them. Set to zero to disable waiting. Set to -1 to always wait for complete batches before sending. NOTE: With lingerMillis set to -1, if you really want to send patial batches, use flush otherwise partial batches will never be sent.|0|
 |`tranquility.maxBatchSize`|Maximum number of messages to send at once.|2000|

--- a/server/src/test/scala/com/metamx/tranquility/server/ServerDruidTest.scala
+++ b/server/src/test/scala/com/metamx/tranquility/server/ServerDruidTest.scala
@@ -122,7 +122,7 @@ object ServerDruidTest
   val TimeFormat = "posix"
 
   def newDruidBeam(curator: CuratorFramework, timekeeper: Timekeeper): Beam[Dict] = {
-    val tuning = ClusteredBeamTuning(Granularity.HOUR, 0.minutes, 10.minutes, 1, 1, 1, 1)
+    val tuning = ClusteredBeamTuning(Granularity.HOUR, 0.minutes, false, 10.minutes, 1, 1, 1, 1)
     val rollup = DruidRollup(
       SpecificDruidDimensions(
         Vector("foo"),


### PR DESCRIPTION
**Description**:
Starts indexing tasks even if there are no incoming events. This is
useful if you have a data source that doesn't have a lot of events, but
you want to be ready when the events start coming in so that they can be
ingested quickly without waiting for indexing tasks to start.

**Work In Progress**:
I'd like to get some input if I'm on right track and if this is something you would merge. I think I got small part of the solution working (not manually tested yet). If you set `task.startImmediately` flag it should create the indexing tasks immediately when tranquility server is started. However creating tasks for the next segment interval does not work yet. This probably involves adding a thread that checks this time to time. Would that be okay?

This PR should also include integrating with `task.warmingPeriod`. Warming period currently works only if you have a constant stream of events (from code: [Possibly warm up future beams](https://github.com/indrekj/tranquility/blob/5830cf056a841d3857d17e505cfa1b1f174f5c3d/core/src/main/scala/com/metamx/tranquility/beam/ClusteredBeam.scala#L356)).
