### PR TITLE
Add support for multiply topic in avro format

### DIFF
--- a/docs/kafka.md
+++ b/docs/kafka.md
@@ -33,6 +33,7 @@ These Kafka-specific properties, if used, may be specified either at the global 
 |`topicPattern`|A regular expression used to match Kafka topics to dataSource configurations. See "Matching Topics to Data Sources" for details.|{match nothing}, must be provided|
 |`topicPattern.priority`|If multiple topicPatterns match the same topic name, the highest priority dataSource configuration will be used. A higher number indicates a higher priority. See "Matching Topics to Data Sources" for details.|1|
 |`useTopicAsDataSource`|Use the Kafka topic as the dataSource name instead of the one provided in the configuration file. Useful when combined with a topicPattern that matches more than one Kafka topic. See "Matching Topics to Data Sources" for details.|false|
+|`useInputTopicAsDecodeTopic`|Use the topic which used by kafka consumer as the avro stream decoder's topic. Useful when consume multiply topic with different avro schema.|true|
 |`reportDropsAsExceptions`|Whether or not dropped messages will cause an exception and terminate the application.|false|
 
 ### Running

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/model/PropertiesBasedKafkaConfig.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/model/PropertiesBasedKafkaConfig.java
@@ -60,6 +60,10 @@ public abstract class PropertiesBasedKafkaConfig extends PropertiesBasedConfig
   @Default("false")
   public abstract Boolean useTopicAsDataSource();
 
+  @Config("useInputTopicAsDecodeTopic")
+  @Default("false")
+  public abstract Boolean useInputTopicAsDecodeTopic();
+
   @Config("topicPattern.priority")
   @Default("1")
   public abstract Integer getTopicPatternPriority();

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/writer/WriterController.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/writer/WriterController.java
@@ -24,6 +24,7 @@ import com.metamx.common.scala.net.curator.Disco;
 import com.metamx.tranquility.config.DataSourceConfig;
 import com.metamx.tranquility.finagle.FinagleRegistry;
 import com.metamx.tranquility.finagle.FinagleRegistryConfig;
+import com.metamx.tranquility.kafka.KafkaBeamUtils;
 import com.metamx.tranquility.kafka.model.MessageCounters;
 import com.metamx.tranquility.kafka.model.PropertiesBasedKafkaConfig;
 import org.apache.curator.RetryPolicy;
@@ -163,7 +164,14 @@ public class WriterController
           )
       );
     }
-
+    if (dataSourceConfig.propertiesBasedConfig().useInputTopicAsDecodeTopic()) {
+      try {
+        dataSourceConfig = KafkaBeamUtils.useInputTopicAsDecodeTopic(topic, dataSourceConfig);
+      }
+      catch (Exception e) {
+        log.warn("Can't use input topic as decode topic.");
+      }
+    }
     return new TranquilityEventWriter(
         topic,
         dataSourceConfig,


### PR DESCRIPTION
In the `TranquilityEventWriter.java` tranquility can instead the druid 's `avroBytesDecoder` topic with the consumer's topic.So the consumer can decode the topic msg with their own decoder. Then tranquility can  consume multiply topic in avro format at once.