### PR TITLE
[Fix] Remove data type and InputRowParser type bindings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ def dependOnDruid(artifact: String) = {
 
 val coreDependencies = Seq(
   "com.metamx" %% "scala-util" % "1.11.6" exclude("log4j", "log4j") force(),
-  "com.metamx" % "java-util" % "0.27.4" exclude("log4j", "log4j") force(),
+  "com.metamx" % "java-util" % "0.27.10" exclude("log4j", "log4j") force(),
   "io.netty" % "netty" % "3.10.5.Final" force(),
   "com.twitter" %% "util-core" % twitterUtilVersion force(),
   "com.twitter" %% "finagle-core" % finagleVersion force(),

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -166,20 +166,20 @@ object DruidBeams
           case t if t == typeTag[ByteBuffer] =>
             val trialParser = mkparser()
             require(
-              trialParser.isInstanceOf[ByteBufferInputRowParser],
-              s"Expected ByteBufferInputRowParser, got[${trialParser.getClass.getName}]"
+              trialParser.isInstanceOf[InputRowParser[ByteBuffer]],
+              s"Expected InputRowParser of ByteBuffer, got[${trialParser.getClass.getName}]"
             )
             val threadLocalParser = new ThreadLocalInputRowParser(mkparser)
-            msg => threadLocalParser.get().asInstanceOf[ByteBufferInputRowParser].parse(msg.asInstanceOf[ByteBuffer])
+            msg => threadLocalParser.get().asInstanceOf[InputRowParser[ByteBuffer]].parse(msg.asInstanceOf[ByteBuffer])
 
           case t if t == typeTag[Array[Byte]] =>
             val trialParser = mkparser()
             require(
-              trialParser.isInstanceOf[ByteBufferInputRowParser],
-              s"Expected ByteBufferInputRowParser, got[${trialParser.getClass.getName}]"
+              trialParser.isInstanceOf[InputRowParser[ByteBuffer]],
+              s"Expected InputRowParser of ByteBuffer, got[${trialParser.getClass.getName}]"
             )
             val threadLocalParser = new ThreadLocalInputRowParser(mkparser)
-            msg => threadLocalParser.get().asInstanceOf[ByteBufferInputRowParser].parse(
+            msg => threadLocalParser.get().asInstanceOf[InputRowParser[ByteBuffer]].parse(
               ByteBuffer.wrap(msg.asInstanceOf[Array[Byte]])
             )
 


### PR DESCRIPTION
see issue #190 

Some warnings of _type erasure_ are mentioned by compiler, seems ok. Tested with local kafka+tranquility+druid, any suggestion to write a reasonable test ? 
