### PR TITLE
extra checks to prevent Tranquilizer of being stuck

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/tranquilizer/Tranquilizer.scala
+++ b/core/src/main/scala/com/metamx/tranquility/tranquilizer/Tranquilizer.scala
@@ -307,6 +307,11 @@ class Tranquilizer[MessageType] private(
         myBuffer.map(_ => Future.exception(new IllegalStateException("sendAll failed", e)))
     }
 
+    assert(myBuffer.nonEmpty)
+    // Check that all beams in the chain respect the contract.
+    // We can't be sure that they are still in the same order but at least we can check that a result exists for all messages sent
+    assert(myBuffer.size == futureResults.size)
+
     val remaining = new AtomicInteger(futureResults.size)
     val sent = new AtomicInteger()
     val dropped = new AtomicInteger()


### PR DESCRIPTION
Tranquilizer relies on Beam chain to respect contract and return future for each message sent with `sendAll`. However it have no control on what Beam implementation is used and will be stuck if `futureResults` is empty. 
We can't check that futures in response are in order but we can at least check the size match and the collection is not empty and fail fast. 