### PR TITLE
Fixes wrong parse exception type being caught by TranquilityEventWriter

### DIFF
--- a/kafka/src/main/java/com/metamx/tranquility/kafka/writer/TranquilityEventWriter.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/writer/TranquilityEventWriter.java
@@ -20,7 +20,7 @@ package com.metamx.tranquility.kafka.writer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
-import com.metamx.common.logger.Logger;
+import io.druid.java.util.common.logger.Logger;
 import io.druid.java.util.common.parsers.ParseException;
 import com.metamx.tranquility.config.DataSourceConfig;
 import com.metamx.tranquility.finagle.FinagleRegistry;

--- a/kafka/src/main/java/com/metamx/tranquility/kafka/writer/TranquilityEventWriter.java
+++ b/kafka/src/main/java/com/metamx/tranquility/kafka/writer/TranquilityEventWriter.java
@@ -21,7 +21,7 @@ package com.metamx.tranquility.kafka.writer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import com.metamx.common.logger.Logger;
-import com.metamx.common.parsers.ParseException;
+import io.druid.java.util.common.parsers.ParseException;
 import com.metamx.tranquility.config.DataSourceConfig;
 import com.metamx.tranquility.finagle.FinagleRegistry;
 import com.metamx.tranquility.kafka.KafkaBeamUtils;


### PR DESCRIPTION
Avro extensions from the Druid codebase throw a ParseException
from the io.druid.java.util.common.parsers package, the Tranquility
code is not catching this as it is expecting the ParseException to
be from the com.metamx.common.parsers package.

This means that broken messages will halt processing regardless of the
reportParseExceptions setting as the exception goes uncaught.

Fixed this to use the ParseException from io.druid.java.util.common.parsers
package