### PR TITLE
Support Basic HTTP auth with druid, TLS support for server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ val curatorVersion = "2.12.0"
 val guiceVersion = "4.0"
 val flinkVersion = "1.0.3"
 val finagleVersion = "6.43.0"
+val finagleHttpAuthVersion = "0.1.0"
 val twitterUtilVersion = "6.42.0"
 val samzaVersion = "0.12.0"
 val sparkVersion = "1.6.0"
@@ -57,6 +58,7 @@ val coreDependencies = Seq(
   "com.twitter" %% "util-core" % twitterUtilVersion force(),
   "com.twitter" %% "finagle-core" % finagleVersion force(),
   "com.twitter" %% "finagle-http" % finagleVersion force(),
+  "com.github.finagle" %% "finagle-http-auth" % finagleHttpAuthVersion force(),
   "org.slf4j" % "slf4j-api" % "1.7.25" force() force(),
   "org.slf4j" % "jul-to-slf4j" % "1.7.25" force() force(),
   "org.apache.httpcomponents" % "httpclient" % apacheHttpVersion force(),

--- a/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
@@ -19,6 +19,9 @@
 
 package com.metamx.tranquility.config
 
+import java.security.KeyStore
+import javax.net.ssl.TrustManagerFactory
+
 import com.metamx.common.scala.net.curator.DiscoAnnounceConfig
 import com.metamx.common.scala.net.curator.DiscoConfig
 import com.metamx.common.scala.untyped.Dict
@@ -114,6 +117,30 @@ abstract class PropertiesBasedConfig(
   @Config(Array("druidBeam.overlordPollPeriod"))
   def overlordPollPeriod = DruidBeamConfig().overlordPollPeriod
 
+  @Config(Array("druidBeam.basicAuthUser"))
+  def basicAuthUser: String = DruidBeamConfig().basicAuthUser
+
+  @Config(Array("druidBeam.basicAuthPass"))
+  def basicAuthPass: String = DruidBeamConfig().basicAuthPass
+
+  @Config(Array("druid.tls.enable"))
+  def tlsEnable: Boolean = false
+
+  @Config(Array("druid.tls.protocol"))
+  def tlsProtocol: String = "TLSv1.2"
+
+  @Config(Array("druid.tls.trustStoreType"))
+  def tlsTrustStoreType: String = KeyStore.getDefaultType()
+
+  @Config(Array("druid.tls.trustStorePath"))
+  def tlsTrustStorePath: String  = ""
+
+  @Config(Array("druid.tls.trustStoreAlgorithm"))
+  def tlsTrustStoreAlgorithm: String  = TrustManagerFactory.getDefaultAlgorithm()
+
+  @Config(Array("druid.tls.trustStorePassword"))
+  def tlsTrustStorePassword: String  = ""
+
   def druidBeamConfig: DruidBeamConfig = DruidBeamConfig.builder()
     .firehoseGracePeriod(firehoseGracePeriod)
     .firehoseQuietPeriod(firehoseQuietPeriod)
@@ -125,6 +152,8 @@ abstract class PropertiesBasedConfig(
     .overlordLocator(overlordLocator)
     .taskLocator(taskLocator)
     .overlordPollPeriod(overlordPollPeriod)
+    .basicAuthUser(basicAuthUser)
+    .basicAuthPass(basicAuthPass)
     .build()
 
   override def discoAnnounce: Option[DiscoAnnounceConfig] = None

--- a/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/config/PropertiesBasedConfig.scala
@@ -67,7 +67,7 @@ abstract class PropertiesBasedConfig(
   def serializationFormat: String = "json"
 
   @Config(Array("zookeeper.connect"))
-  def zookeeperConnect: String
+  def zookeeperConnect: String = "localhost:2181"
 
   @Config(Array("zookeeper.timeout"))
   def zookeeperTimeout: Period = new Period("PT20S")

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
@@ -53,7 +53,11 @@ class DruidBeam[A](
         task ->
           new TaskClient(
             task,
-            BasicAuthClientMaker.wrapBaseClient(taskLocator.connect(task), config.basicAuthUser, config.basicAuthPass),
+            BasicAuthClientMaker.wrapBaseClient(
+              taskLocator.connect(task),
+              Some(config.basicAuthUser),
+              Some(config.basicAuthPass)
+            ),
             location.dataSource,
             config.firehoseQuietPeriod,
             config.firehoseRetryPeriod,

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeam.scala
@@ -26,7 +26,9 @@ import com.metamx.tranquility.beam.Beam
 import com.metamx.tranquility.beam.DefunctBeamException
 import com.metamx.tranquility.beam.SendResult
 import com.metamx.tranquility.finagle._
+import com.metamx.tranquility.security._
 import com.metamx.tranquility.typeclass.ObjectWriter
+import com.twitter.finagle.{http, Service}
 import com.twitter.io.Buf
 import com.twitter.util._
 
@@ -51,7 +53,7 @@ class DruidBeam[A](
         task ->
           new TaskClient(
             task,
-            taskLocator.connect(task),
+            BasicAuthClientMaker.wrapBaseClient(taskLocator.connect(task), config.basicAuthUser, config.basicAuthPass),
             location.dataSource,
             config.firehoseQuietPeriod,
             config.firehoseRetryPeriod,

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamConfig.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeamConfig.scala
@@ -30,7 +30,9 @@ case class DruidBeamConfig(
   firehoseBufferSize: Int = 100000,
   overlordLocator: String = OverlordLocator.Curator,
   taskLocator: String = TaskLocator.Curator,
-  overlordPollPeriod: Period = 20.seconds
+  overlordPollPeriod: Period = 20.seconds,
+  basicAuthUser: String = "",
+  basicAuthPass: String = ""
 ) extends IndexServiceConfig
 
 object DruidBeamConfig
@@ -118,6 +120,16 @@ object DruidBeamConfig
       * Default is 20 seconds.
       */
     def overlordPollPeriod(x: Period) = new Builder(config.copy(overlordPollPeriod = x))
+
+    /**
+      * Username for HTTP Basic authentication.
+      */
+    def basicAuthUser(x: String) = new Builder(config.copy(basicAuthUser = x))
+
+    /**
+      * Password for HTTP Basic authentication.
+      */
+    def basicAuthPass(x: String) = new Builder(config.copy(basicAuthPass = x))
 
     def build(): DruidBeamConfig = config
   }

--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -931,11 +931,12 @@ object DruidBeams extends Logging
           def discoPath = discoveryPath
         }
       )
+      val generalConfig           = _generalConfig getOrElse PropertiesBasedConfig.fromDict(Dict(), classOf[PropertiesBasedConfig])
 
       val finagleRegistry = _finagleRegistry getOrElse {
         val finagleRegistryConfig = FinagleRegistryConfig
           .builder()
-          .sslContextOption(SSLContextMaker.createSSLContextOption(_generalConfig.get))
+          .sslContextOption(SSLContextMaker.createSSLContextOption(generalConfig))
           .build()
         new FinagleRegistry(finagleRegistryConfig, Nil)
       }
@@ -948,7 +949,7 @@ object DruidBeams extends Logging
         location.environment,
         druidBeamConfig,
         overlordLocator,
-        _generalConfig.get
+        generalConfig
       )
       val taskLocator             = TaskLocator.create(
         druidBeamConfig.taskLocator,
@@ -977,7 +978,6 @@ object DruidBeams extends Logging
           new MergingPartitioningBeam[EventType](partitioner, beams.toIndexedSeq)
         }
       }
-      val generalConfig           = _generalConfig getOrElse PropertiesBasedConfig
     }
   }
 

--- a/core/src/main/scala/com/metamx/tranquility/druid/IndexService.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/IndexService.scala
@@ -46,7 +46,8 @@ class IndexService(
   environment: DruidEnvironment,
   config: IndexServiceConfig,
   overlordLocator: OverlordLocator,
-  generalConfig: PropertiesBasedConfig
+  basicAuthUser: Option[String],
+  basicAuthPass: Option[String]
 ) extends Closable
 {
   private implicit val timer: Timer = DefaultTimer.twitter
@@ -64,8 +65,8 @@ class IndexService(
       if (_client == null) {
         _client = BasicAuthClientMaker.wrapBaseClient(
           overlordLocator.connect(),
-          generalConfig.basicAuthUser,
-          generalConfig.basicAuthPass
+          basicAuthUser,
+          basicAuthPass
         )
       }
 

--- a/core/src/main/scala/com/metamx/tranquility/druid/IndexService.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/IndexService.scala
@@ -25,9 +25,11 @@ import com.metamx.common.scala.Predef._
 import com.metamx.common.scala.control._
 import com.metamx.common.scala.exception._
 import com.metamx.common.scala.untyped._
+import com.metamx.tranquility.config.PropertiesBasedConfig
 import com.metamx.tranquility.druid.IndexService.TaskHostPort
 import com.metamx.tranquility.druid.IndexService.TaskId
 import com.metamx.tranquility.finagle._
+import com.metamx.tranquility.security.BasicAuthClientMaker
 import com.twitter.finagle.util.DefaultTimer
 import com.twitter.finagle.Addr
 import com.twitter.finagle.Address
@@ -43,7 +45,8 @@ import java.net.InetSocketAddress
 class IndexService(
   environment: DruidEnvironment,
   config: IndexServiceConfig,
-  overlordLocator: OverlordLocator
+  overlordLocator: OverlordLocator,
+  generalConfig: PropertiesBasedConfig
 ) extends Closable
 {
   private implicit val timer: Timer = DefaultTimer.twitter
@@ -59,7 +62,11 @@ class IndexService(
       }
 
       if (_client == null) {
-        _client = overlordLocator.connect()
+        _client = BasicAuthClientMaker.wrapBaseClient(
+          overlordLocator.connect(),
+          generalConfig.basicAuthUser,
+          generalConfig.basicAuthPass
+        )
       }
 
       _client

--- a/core/src/main/scala/com/metamx/tranquility/security/BasicAuthClientMaker.scala
+++ b/core/src/main/scala/com/metamx/tranquility/security/BasicAuthClientMaker.scala
@@ -27,14 +27,14 @@ object BasicAuthClientMaker extends Logging
 {
   def wrapBaseClient(
     baseClient: Service[http.Request, http.Response],
-    basicAuthUser: String,
-    basicAuthPass: String
+    basicAuthUser: Option[String],
+    basicAuthPass: Option[String]
   ): Service[http.Request, http.Response] = {
-    if (basicAuthUser.length > 0 && basicAuthPass.length > 0) {
-      log.info("Using BasicAuth.Client...")
-      BasicAuth.client(basicAuthUser, basicAuthPass).andThen(baseClient)
+    if (basicAuthUser.isDefined && basicAuthPass.isDefined) {
+      log.info("Using BasicAuth.Client.")
+      BasicAuth.client(basicAuthUser.get, basicAuthPass.get).andThen(baseClient)
     } else {
-      log.info("Using client without authentication..")
+      log.info("Using client without authentication.")
       baseClient
     }
   }

--- a/core/src/main/scala/com/metamx/tranquility/security/BasicAuthClientMaker.scala
+++ b/core/src/main/scala/com/metamx/tranquility/security/BasicAuthClientMaker.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.metamx.tranquility.security
+
+import com.metamx.common.scala.Logging
+import com.twitter.finagle.{http, Service}
+import com.twitter.finagle.http.BasicAuth
+
+object BasicAuthClientMaker extends Logging
+{
+  def wrapBaseClient(
+    baseClient: Service[http.Request, http.Response],
+    basicAuthUser: String,
+    basicAuthPass: String
+  ): Service[http.Request, http.Response] = {
+    if (basicAuthUser.length > 0 && basicAuthPass.length > 0) {
+      log.info("Using BasicAuth.Client...")
+      BasicAuth.client(basicAuthUser, basicAuthPass).andThen(baseClient)
+    } else {
+      log.info("Using client without authentication..")
+      baseClient
+    }
+  }
+}

--- a/core/src/main/scala/com/metamx/tranquility/security/SSLContextMaker.scala
+++ b/core/src/main/scala/com/metamx/tranquility/security/SSLContextMaker.scala
@@ -1,0 +1,45 @@
+package com.metamx.tranquility.security
+
+import java.io.FileInputStream
+import java.io.IOException
+import java.security.{NoSuchAlgorithmException, KeyStoreException, KeyManagementException, KeyStore}
+import java.security.cert.CertificateException
+import javax.net.ssl.{TrustManagerFactory, SSLContext}
+
+import com.metamx.common.scala.Logging
+import com.metamx.tranquility.config.PropertiesBasedConfig
+
+object SSLContextMaker extends Logging
+{
+  def createSSLContextOption(generalConfig: PropertiesBasedConfig): Option[SSLContext] = {
+    if (!generalConfig.tlsEnable) {
+      log.info("TLS is not enabled, skipping SSLContext creation.")
+      return Option.empty[SSLContext]
+    }
+
+    log.info("TLS is enabled, creating SSLContext.")
+
+    var sslContext: SSLContext = null
+    try {
+      sslContext = SSLContext.getInstance(generalConfig.tlsProtocol)
+      var keyStore = KeyStore.getInstance(generalConfig.tlsTrustStoreType)
+      keyStore.load(
+        new FileInputStream(generalConfig.tlsTrustStorePath),
+        generalConfig.tlsTrustStorePassword.toCharArray
+      )
+      var trustManagerFactory = TrustManagerFactory.getInstance(generalConfig.tlsTrustStoreAlgorithm)
+      trustManagerFactory.init(keyStore)
+      sslContext.init(null, trustManagerFactory.getTrustManagers, null)
+    }
+    catch {
+      case ex@(_: CertificateException |
+               _: KeyManagementException |
+               _: IOException |
+               _: KeyStoreException |
+               _: NoSuchAlgorithmException) =>
+        throw new RuntimeException(ex)
+    }
+
+    Option.apply(sslContext)
+  }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,12 @@ Any of these properties can be specified either globally, or per-dataSource.
 |--------|-----------|-------|
 |`druid.discovery.curator.path`|Curator service discovery path. This is assumed to be on the same zookeeper cluster as `zookeeper.connect` refers to.|/druid/discovery|
 |`druid.selectors.indexing.serviceName`|The druid.service name of the indexing service Overlord node.|druid/overlord|
+|`druid.tls.enable`|Enable TLS when communicating with Druid|false|
+|`druid.tls.protocol`|TLS protocol version to use.|'TLSv1.2'|
+|`druid.tls.trustStorePath`|Path of the keystore containing trusted root certificates, used to validate the certificate provided by Druid.|''|
+|`druid.tls.trustStoreType`|Type of the keystore containig trusted root certificates.|KeyStore.getDefaultType()|
+|`druid.tls.trustStoreAlgorithm`|Algorithm to be used by TrustManager to validate certificate chains.|TrustManagerFactory.getDefaultAlgorithm()|
+|`druid.tls.trustStorePassword`|Password for the keystore containing trusted root certifcates.|''|
 |`druidBeam.firehoseBufferSize`|Size of buffer used by firehose to store events.|100000|
 |`druidBeam.firehoseChunkSize`|Maximum number of events to send to Druid in one HTTP request.|1000|
 |`druidBeam.firehoseGracePeriod`|Druid indexing tasks will shut down this long after the windowPeriod has elapsed.|PT5M|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ Any of these properties can be specified either globally, or per-dataSource.
 |--------|-----------|-------|
 |`druid.discovery.curator.path`|Curator service discovery path. This is assumed to be on the same zookeeper cluster as `zookeeper.connect` refers to.|/druid/discovery|
 |`druid.selectors.indexing.serviceName`|The druid.service name of the indexing service Overlord node.|druid/overlord|
-|`druid.tls.enable`|Enable TLS when communicating with Druid|false|
+|`druid.tls.enable`|Enable TLS when communicating with Druid. If the Druid cluster does not have TLS enabled, this must be set to false as well.|false|
 |`druid.tls.protocol`|TLS protocol version to use.|'TLSv1.2'|
 |`druid.tls.trustStorePath`|Path of the keystore containing trusted root certificates, used to validate the certificate provided by Druid.|''|
 |`druid.tls.trustStoreType`|Type of the keystore containig trusted root certificates.|KeyStore.getDefaultType()|

--- a/docs/server.md
+++ b/docs/server.md
@@ -84,7 +84,19 @@ These Server-specific properties, if used, must be specified at the global level
 
 |Property|Description|Default|
 |--------|-----------|-------|
-|`http.port`|Port to listen on.|8200|
+|`http.port`|Port to listen on, with plaintext traffic|8200|
+|`http.port.enable`|Enable the port for plaintext traffic.|true|
+|`https.port`|Port to listen on, with TLS.|8400|
+|`https.port.enable`|Enable the TLS port.|false|
+|`https.keyStorePath`|Path of the keystore file that contains Traquility Server's TLS certificate.|''|
+|`https.keyStorePassword`|Password for the keystore|''|
+|`https.certAlias`|Alias of the server certificate in the keystore|''|
+|`https.keyManagerFactoryAlgorithm`|Algorithm to use for creating KeyManager, more details [here](https://docs.oracle.com/javase/7/docs/technotes/guides/security/jsse/JSSERefGuide.html#KeyManager).|KeyManagerFactory.getDefaultAlgorithm()|
+|`https.keyManagerPassword`|Password for the KeyManager|''|
+|`https.includeCipherSuites`|List of cipher suite names to include. You can either use the exact cipher suite name or a regular expression.|Jetty's default include cipher list|
+|`https.excludeCipherSuites`|List of cipher suite names to exclude. You can either use the exact cipher suite name or a regular expression.|Jetty's default exclude cipher list|
+|`https.includeProtocols`|List of exact protocols names to include.|Jetty's default include protocol list|
+|`https.excludeProtocols`|List of exact protocols names to exclude.|Jetty's default exclude protocol list|
 |`http.threads`|Number of threads for serving HTTP requests.|40|
 |`http.idleTimeout`|Abort connections that have had no activity for longer than this timeout. Set to zero to disable. ISO8601 duration.|PT5M|
 

--- a/server/src/main/scala/com/metamx/tranquility/server/PropertiesBasedServerConfig.scala
+++ b/server/src/main/scala/com/metamx/tranquility/server/PropertiesBasedServerConfig.scala
@@ -20,7 +20,7 @@
 package com.metamx.tranquility.server
 
 import java.security.KeyStore
-import java.util
+import java.{util => ju}
 import javax.net.ssl.KeyManagerFactory
 
 import com.metamx.tranquility.config.PropertiesBasedConfig
@@ -61,16 +61,16 @@ abstract class PropertiesBasedServerConfig
   def httpsKeyManagerPassword: String = ""
 
   @Config(Array("https.includeCipherSuites"))
-  def httpsIncludeCipherSuites: util.List[String] = null
+  def httpsIncludeCipherSuites: ju.List[String] = null
 
   @Config(Array("https.excludeCipherSuites"))
-  def httpsExcludeCipherSuites: util.List[String] = null
+  def httpsExcludeCipherSuites: ju.List[String] = null
 
   @Config(Array("https.includeProtocols"))
-  def httpsIncludeProtocols: util.List[String] = null
+  def httpsIncludeProtocols: ju.List[String] = null
 
   @Config(Array("https.excludeProtocols"))
-  def httpsExcludeProtocols: util.List[String] = null
+  def httpsExcludeProtocols: ju.List[String] = null
 
   @Config(Array("http.threads"))
   def httpThreads: Int = 40

--- a/server/src/main/scala/com/metamx/tranquility/server/PropertiesBasedServerConfig.scala
+++ b/server/src/main/scala/com/metamx/tranquility/server/PropertiesBasedServerConfig.scala
@@ -19,6 +19,10 @@
 
 package com.metamx.tranquility.server
 
+import java.security.KeyStore
+import java.util
+import javax.net.ssl.KeyManagerFactory
+
 import com.metamx.tranquility.config.PropertiesBasedConfig
 import org.joda.time.Period
 import org.skife.config.Config
@@ -28,6 +32,45 @@ abstract class PropertiesBasedServerConfig
 {
   @Config(Array("http.port"))
   def httpPort: Int = 8200
+
+  @Config(Array("http.port.enable"))
+  def httpPortEnable: Boolean = true
+
+  @Config(Array("https.port"))
+  def httpsPort: Int = 8400
+
+  @Config(Array("https.port.enable"))
+  def httpsPortEnable: Boolean = false
+
+  @Config(Array("https.keyStorePath"))
+  def httpsKeyStorePath: String = ""
+
+  @Config(Array("https.keyStoreType"))
+  def httpsKeyStoreType: String = KeyStore.getDefaultType
+
+  @Config(Array("https.keyStorePassword"))
+  def httpsKeyStorePassword: String = ""
+
+  @Config(Array("https.certAlias"))
+  def httpsCertAlias: String = ""
+
+  @Config(Array("https.keyManagerFactoryAlgorithm"))
+  def httpsKeyManagerFactoryAlgorithm: String = KeyManagerFactory.getDefaultAlgorithm
+
+  @Config(Array("https.keyManagerPassword"))
+  def httpsKeyManagerPassword: String = ""
+
+  @Config(Array("https.includeCipherSuites"))
+  def httpsIncludeCipherSuites: util.List[String] = null
+
+  @Config(Array("https.excludeCipherSuites"))
+  def httpsExcludeCipherSuites: util.List[String] = null
+
+  @Config(Array("https.includeProtocols"))
+  def httpsIncludeProtocols: util.List[String] = null
+
+  @Config(Array("https.excludeProtocols"))
+  def httpsExcludeProtocols: util.List[String] = null
 
   @Config(Array("http.threads"))
   def httpThreads: Int = 40

--- a/server/src/main/scala/com/metamx/tranquility/server/http/ServerMain.scala
+++ b/server/src/main/scala/com/metamx/tranquility/server/http/ServerMain.scala
@@ -19,6 +19,8 @@
 
 package com.metamx.tranquility.server.http
 
+import java.util
+
 import com.github.nscala_time.time.Imports._
 import com.metamx.common.lifecycle.Lifecycle
 import com.metamx.common.scala.Predef._
@@ -33,21 +35,24 @@ import com.metamx.tranquility.config.TranquilityConfig
 import com.metamx.tranquility.druid.DruidBeams
 import com.metamx.tranquility.finagle.FinagleRegistry
 import com.metamx.tranquility.finagle.FinagleRegistryConfig
+import com.metamx.tranquility.security.SSLContextMaker
 import com.metamx.tranquility.server.PropertiesBasedServerConfig
 import com.twitter.app.App
 import com.twitter.app.Flag
 import io.druid.data.input.InputRow
 import java.io.FileInputStream
 import org.apache.curator.framework.CuratorFramework
-import org.eclipse.jetty.server.Server
-import org.eclipse.jetty.server.ServerConnector
+import org.eclipse.jetty.server._
 import org.eclipse.jetty.servlet.ServletHandler
 import org.eclipse.jetty.servlet.ServletHolder
+import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.util.thread.QueuedThreadPool
+import scala.collection.mutable.ListBuffer
 import scala.reflect.runtime.universe.typeTag
 
 object ServerMain extends App with Logging
 {
+  private val HTTP_1_1_STRING: String = "HTTP/1.1"
   private val ConfigResource = "tranquility-server.yaml"
 
   private val configFile: Flag[String] = flag(
@@ -110,7 +115,8 @@ object ServerMain extends App with Logging
       val finagleRegistry = finagleRegistries.getOrElseUpdate(
         (zookeeperConnect, discoPath), {
           val disco = lifecycle.addManagedInstance(new Disco(curator, dataSourceConfig.propertiesBasedConfig))
-          new FinagleRegistry(FinagleRegistryConfig(), disco)
+          val sslContext = SSLContextMaker.createSSLContextOption(config.globalConfig)
+          new FinagleRegistry(FinagleRegistryConfig(sslContextOption = sslContext), disco)
         }
       )
 
@@ -127,6 +133,88 @@ object ServerMain extends App with Logging
     new TranquilityServlet(bundles)
   }
 
+  def createPlaintextConnector(
+    server: Server,
+    config: TranquilityConfig[PropertiesBasedServerConfig]
+  ): ServerConnector =
+  {
+    val connector = new ServerConnector(server)
+    connector.setPort(config.globalConfig.httpPort)
+    config.globalConfig.httpIdleTimeout.standardDuration.millis match {
+      case timeout if timeout > 0 =>
+        connector.setIdleTimeout(timeout)
+      case _ =>
+    }
+    connector
+  }
+
+  def createTLSConnector(
+    server: Server,
+    config: TranquilityConfig[PropertiesBasedServerConfig]
+  ): ServerConnector =
+  {
+    val sslContextFactory = createSslContextFactory(config)
+
+    val httpsConfiguration : HttpConfiguration = new HttpConfiguration
+    httpsConfiguration.setSecureScheme("https")
+    httpsConfiguration.setSecurePort(config.globalConfig.httpsPort)
+    httpsConfiguration.addCustomizer(new SecureRequestCustomizer)
+    httpsConfiguration.setRequestHeaderSize(8 * 1024)
+
+    val connector : ServerConnector = new ServerConnector(
+      server,
+      new SslConnectionFactory(sslContextFactory, HTTP_1_1_STRING),
+      new HttpConnectionFactory(httpsConfiguration)
+    )
+
+    connector.setPort(config.globalConfig.httpsPort)
+    config.globalConfig.httpIdleTimeout.standardDuration.millis match {
+      case timeout if timeout > 0 =>
+        connector.setIdleTimeout(timeout)
+      case _ =>
+    }
+    connector
+  }
+
+  def createSslContextFactory(
+    config: TranquilityConfig[PropertiesBasedServerConfig]
+  ): SslContextFactory = {
+    val sslContextFactory = new SslContextFactory(false)
+    sslContextFactory.setKeyStorePath("")
+
+    sslContextFactory.setKeyStorePath(config.globalConfig.httpsKeyStorePath)
+    sslContextFactory.setKeyStoreType(config.globalConfig.httpsKeyStoreType)
+    sslContextFactory.setKeyStorePassword(config.globalConfig.httpsKeyStorePassword)
+    sslContextFactory.setCertAlias(config.globalConfig.httpsCertAlias)
+    sslContextFactory.setSslKeyManagerFactoryAlgorithm(config.globalConfig.httpsKeyManagerFactoryAlgorithm)
+    sslContextFactory.setKeyManagerPassword(config.globalConfig.httpsKeyManagerPassword)
+    if (config.globalConfig.httpsIncludeCipherSuites != null) {
+      val suites: Array[String] = config.globalConfig.httpsIncludeCipherSuites.toArray(
+        new Array[String](config.globalConfig.httpsIncludeCipherSuites.size())
+      )
+      sslContextFactory.setIncludeCipherSuites(suites: _*)
+    }
+    if (config.globalConfig.httpsExcludeCipherSuites != null) {
+      val suites: Array[String] = config.globalConfig.httpsExcludeCipherSuites.toArray(
+        new Array[String](config.globalConfig.httpsExcludeCipherSuites.size())
+      )
+      sslContextFactory.setExcludeCipherSuites(suites: _*)
+    }
+    if (config.globalConfig.httpsIncludeProtocols != null) {
+      val protocols: Array[String] = config.globalConfig.httpsIncludeProtocols.toArray(
+        new Array[String](config.globalConfig.httpsIncludeProtocols.size())
+      )
+      sslContextFactory.setIncludeProtocols(protocols: _*)
+    }
+    if (config.globalConfig.httpsExcludeProtocols != null) {
+      val protocols: Array[String] = config.globalConfig.httpsExcludeProtocols.toArray(
+        new Array[String](config.globalConfig.httpsExcludeProtocols.size())
+      )
+      sslContextFactory.setExcludeProtocols(protocols: _*)
+    }
+    sslContextFactory
+  }
+
   def createJettyServer(
     lifecycle: Lifecycle,
     config: TranquilityConfig[PropertiesBasedServerConfig],
@@ -134,14 +222,15 @@ object ServerMain extends App with Logging
   ): Server =
   {
     new Server(new QueuedThreadPool(config.globalConfig.httpThreads)) withEffect { server =>
-      val connector = new ServerConnector(server)
-      server.setConnectors(Array(connector))
-      connector.setPort(config.globalConfig.httpPort)
-      config.globalConfig.httpIdleTimeout.standardDuration.millis match {
-        case timeout if timeout > 0 =>
-          connector.setIdleTimeout(timeout)
-        case _ =>
+
+      val connectors: ListBuffer[ServerConnector] = ListBuffer[ServerConnector]()
+      if (config.globalConfig.httpPortEnable) {
+        connectors += createPlaintextConnector(server, config)
       }
+      if (config.globalConfig.httpsPortEnable) {
+        connectors += createTLSConnector(server, config)
+      }
+      server.setConnectors(connectors.toArray)
 
       server.setHandler(
         new ServletHandler withEffect { handler =>

--- a/server/src/main/scala/com/metamx/tranquility/server/http/ServerMain.scala
+++ b/server/src/main/scala/com/metamx/tranquility/server/http/ServerMain.scala
@@ -115,7 +115,14 @@ object ServerMain extends App with Logging
       val finagleRegistry = finagleRegistries.getOrElseUpdate(
         (zookeeperConnect, discoPath), {
           val disco = lifecycle.addManagedInstance(new Disco(curator, dataSourceConfig.propertiesBasedConfig))
-          val sslContext = SSLContextMaker.createSSLContextOption(config.globalConfig)
+          val sslContext = SSLContextMaker.createSSLContextOption(
+            Some(config.globalConfig.tlsEnable),
+            Some(config.globalConfig.tlsProtocol),
+            Some(config.globalConfig.tlsTrustStoreType),
+            Some(config.globalConfig.tlsTrustStorePath),
+            Some(config.globalConfig.tlsTrustStoreAlgorithm),
+            Some(config.globalConfig.tlsTrustStorePassword)
+          )
           new FinagleRegistry(FinagleRegistryConfig(sslContextOption = sslContext), disco)
         }
       )
@@ -180,8 +187,6 @@ object ServerMain extends App with Logging
     config: TranquilityConfig[PropertiesBasedServerConfig]
   ): SslContextFactory = {
     val sslContextFactory = new SslContextFactory(false)
-    sslContextFactory.setKeyStorePath("")
-
     sslContextFactory.setKeyStorePath(config.globalConfig.httpsKeyStorePath)
     sslContextFactory.setKeyStoreType(config.globalConfig.httpsKeyStoreType)
     sslContextFactory.setKeyStorePassword(config.globalConfig.httpsKeyStorePassword)


### PR DESCRIPTION
This PR adds support for Basic HTTP authentication when Tranquility communicates with Druid.

The PR also adds configuration options that allow Tranquility Server to accept requests with TLS and communicate with a TLS-enabled Druid cluster.