### PR TITLE
Spark: correctly log records received.

### DIFF
--- a/spark/src/main/scala/com/metamx/tranquility/spark/BeamRDD.scala
+++ b/spark/src/main/scala/com/metamx/tranquility/spark/BeamRDD.scala
@@ -48,6 +48,7 @@ class BeamRDD[T: ClassTag](rdd: RDD[T]) extends Logging with Serializable
         val exception = new AtomicReference[Throwable]
 
         for (record <- partitionOfRecords) {
+          received.incrementAndGet()
           sender.send(record) respond {
             case Return(_) => sent.incrementAndGet()
             case Throw(e: MessageDroppedException) => // Suppress


### PR DESCRIPTION
Currently `received` never gets incremented and it is always `0` in the debugging log a few lines below: `Sent ${sent.get()} out of ${received.get()} events to Druid.`
This PR increments `received` for every record.