### PR TITLE
Handling exceptions while closing BeamSink

### DIFF
--- a/flink/src/main/scala/com/metamx/tranquility/flink/BeamSink.scala
+++ b/flink/src/main/scala/com/metamx/tranquility/flink/BeamSink.scala
@@ -68,6 +68,7 @@ class BeamSink[T](beamFactory: BeamFactory[T], reportDropsAsExceptions: Boolean 
   override def close() = {
     sender.get.flush()
     maybeThrow()
+    sender.get.stop()
   }
 
   private def maybeThrow() {


### PR DESCRIPTION
Currently Flink is not able to close the BeamSink properly when Tranquility isn't initialised properly in open method. The initialisation can be prohibited due to NoClassDefFoundError in usual scenarios due to dependency conflicts. As a result Flink throws 

> ERROR org.apache.flink.streaming.runtime.tasks.StreamTask           - Error during disposal of stream operator.
> java.util.NoSuchElementException: None.get

This pull request catches this error and simply logs it.
