### PR TITLE
When enable TLS in configuration can't set the store path

### DIFF
--- a/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
+++ b/core/src/main/scala/com/metamx/tranquility/druid/DruidBeams.scala
@@ -366,6 +366,8 @@ object DruidBeams extends Logging
       .tlsTrustStoreAlgorithm(config.propertiesBasedConfig.tlsTrustStoreAlgorithm)
       .tlsTrustStoreType(config.propertiesBasedConfig.tlsTrustStoreType)
       .tlsTrustStorePassword(config.propertiesBasedConfig.tlsTrustStorePassword)
+      .tlsTrustStorePath(config.propertiesBasedConfig.tlsTrustStorePath)
+
   }
 
   /**


### PR DESCRIPTION
This leads to `FileNotFound` exception.
Add the missing set of tlsTrustStorePath