### PR TITLE
Update readme to give info about the state of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Storm, and Trident.
 
 This project is a friend of Druid. For discussion, feel free to use the normal Druid channels: http://druid.io/community/
 
+This project is in maintenance mode. It is not the recommended way to ingest data into Druid for new projects. Please refer to the [documents](https://druid.staged.apache.org/docs/latest/ingestion/tranquility.html) for recommended ways to ingest data.
+
 ### Documentation
 
 General:


### PR DESCRIPTION
I added a section on readme to inform users about the state of the project. Druid docs say that it is not the recommended way to ingest data. See [here](https://github.com/apache/druid/releases/tag/druid-0.16.0-incubating#docs) and [here](https://druid.staged.apache.org/docs/latest/ingestion/tranquility.html). We should let people now that when they stumble upon this repository that there might be a better way to ingest data.